### PR TITLE
[Fix] Finalize lint

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,6 +4,7 @@
     "reason-string": ["off"],
     "not-rely-on-time": ["off"],
     "compiler-version": ["error", "^0.8.0"],
-    "func-visibility": ["warn", { "ignoreConstructors": true }]
+    "func-visibility": ["warn", { "ignoreConstructors": true }],
+    "const-name-snakecase": ["off"]
   }
 }

--- a/packages/perennial-provider/contracts/oracle/UOracleProvider.sol
+++ b/packages/perennial-provider/contracts/oracle/UOracleProvider.sol
@@ -22,6 +22,7 @@ abstract contract UOracleProvider is OracleProvider, UOwnable {
      * @notice Initializes the contract state
      * @param initialOracle Initial oracle for the product
      */
+    // solhint-disable-next-line func-name-mixedcase
     function __UOracleProvider__initialize(IOracleProvider initialOracle)
     internal onlyInitializer {
         updateOracle(initialOracle);

--- a/packages/perennial-provider/contracts/product/UProductProvider.sol
+++ b/packages/perennial-provider/contracts/product/UProductProvider.sol
@@ -45,6 +45,7 @@ abstract contract UProductProvider is ProductProvider, UOwnable {
      * @param takerFee_ Initial taker fee value
      * @param makerLimit_ Initial maker limit value
      */
+    // solhint-disable-next-line func-name-mixedcase
     function __UProductProvider__initialize(
         UFixed18 maintenance_,
         UFixed18 fundingFee_,

--- a/packages/perennial/contracts/forwarder/Forwarder.sol
+++ b/packages/perennial/contracts/forwarder/Forwarder.sol
@@ -14,10 +14,10 @@ import "../interfaces/ICollateral.sol";
  */
 contract Forwarder {
     // @dev USDC stablecoin
-    Token6 public immutable USDC;
+    Token6 public immutable USDC; // solhint-disable-line var-name-mixedcase
 
     // @dev DSU stablecoin
-    Token18 public immutable DSU;
+    Token18 public immutable DSU; // solhint-disable-line var-name-mixedcase
 
     /// @dev Contract that wraps USDC to DSU
     IBatcher public immutable batcher;


### PR DESCRIPTION
- Turns off `const-name-snakecase` since this interferes with our unstructured storage patter.
- Adds `func-name-mixedcase` disable to initializers

* Resolves all outstanding lint warnings