### PR TITLE
Postinstall -> prepare

### DIFF
--- a/packages/perennial-provider-template/package.json
+++ b/packages/perennial-provider-template/package.json
@@ -20,8 +20,7 @@
     "coverage:integration": "FORK_ENABLED=true FORK_BLOCK_NUMBER=14325080 hardhat coverage --testfiles 'test/integration/*'",
     "lint": "eslint --fix --ext '.ts,.js' ./ && solhint 'contracts/**/*.sol' --fix",
     "format": "prettier -w .",
-    "postinstall": "yarn build",
-    "prepare": "husky install",
+    "prepare": "yarn build",
     "clean": "rm -rf cache artifacts types/generated",
     "node:fork:kovan": "HARDHAT_DEPLOY_FORK=kovan FORK_NETWORK=kovan FORK_ENABLED=true hardhat node",
     "prepack": "yarn build && rm -rf ./artifacts/contracts/**/*.dbg.json"
@@ -29,7 +28,7 @@
   "author": "",
   "license": "APACHE-2.0",
   "devDependencies": {
-    "@equilibria/perennial": "0.1.5",
-    "@equilibria/perennial-provider": "0.1.5"
+    "@equilibria/perennial": "0.1.6",
+    "@equilibria/perennial-provider": "0.1.6"
   }
 }

--- a/packages/perennial-provider/package.json
+++ b/packages/perennial-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equilibria/perennial-provider",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Library for Perennial product providers",
   "files": [
     "contracts/oracle",
@@ -21,7 +21,7 @@
     "coverage:integration": "FORK_ENABLED=true FORK_BLOCK_NUMBER=14325080 hardhat coverage --testfiles 'test/integration/*'",
     "lint": "eslint --fix --ext '.ts,.js' ./ && solhint 'contracts/**/*.sol' --fix",
     "format": "prettier -w .",
-    "postinstall": "yarn build",
+    "prepare": "yarn build",
     "clean": "rm -rf cache artifacts types/generated",
     "node:fork:kovan": "HARDHAT_DEPLOY_FORK=kovan FORK_NETWORK=kovan FORK_ENABLED=true hardhat node",
     "prepack": "yarn build && rm -rf ./artifacts/contracts/**/*.dbg.json"
@@ -29,7 +29,7 @@
   "author": "",
   "license": "APACHE-2.0",
   "dependencies": {
-    "@equilibria/perennial": "0.1.5",
+    "@equilibria/perennial": "0.1.6",
     "@equilibria/root": "0.1.5",
     "@openzeppelin/contracts": "4.6.0"
   }

--- a/packages/perennial/package.json
+++ b/packages/perennial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equilibria/perennial",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Perennial Protocol Core",
   "files": [
     "contracts/interfaces",
@@ -19,7 +19,7 @@
     "coverage:integration": "FORK_ENABLED=true FORK_BLOCK_NUMBER=14325080 hardhat coverage --testfiles 'test/integration/*'",
     "lint": "eslint --fix --ext '.ts,.js' ./ && solhint 'contracts/**/*.sol' --fix",
     "format": "prettier -w .",
-    "postinstall": "yarn build",
+    "prepare": "yarn build",
     "clean": "rm -rf cache artifacts types/generated",
     "node:fork:kovan": "HARDHAT_DEPLOY_FORK=kovan FORK_NETWORK=kovan FORK_ENABLED=true hardhat node",
     "prepack": "yarn build && rm -rf ./artifacts/contracts/**/*.dbg.json"


### PR DESCRIPTION
Moves the `postinstall` scripts to `prepare`. The `postinstall` is run whenever someone installs this package, which creates a hard dependency on hardhat which is not what we want. `prepare` is only run when we do `yarn install` locally for development, which is what we want.