### PR TITLE
[Fix] B01 - Liquidation Flag is not properly cleared

### DIFF
--- a/packages/perennial/contracts/product/types/position/AccountPosition.sol
+++ b/packages/perennial/contracts/product/types/position/AccountPosition.sol
@@ -35,7 +35,10 @@ library AccountPositionLib {
     ) internal returns (UFixed18 positionFee) {
         bool settled;
         (self.position, positionFee, settled) = self.position.settled(self.pre, provider, toOracleVersion);
-        if (settled) delete self.pre;
+        if (settled) {
+            delete self.pre;
+            self.liquidation = false;
+        }
     }
 
     /**

--- a/packages/perennial/test/integration/liquidate.test.ts
+++ b/packages/perennial/test/integration/liquidate.test.ts
@@ -39,6 +39,11 @@ describe('Liquidate', () => {
     expect(await collateral['collateral(address,address)'](user.address, product.address)).to.equal(0)
     expect(await collateral['collateral(address)'](product.address)).to.equal(0)
     expect(await dsu.balanceOf(userB.address)).to.equal(utils.parseEther('21000')) // Original 20000 + fee
+
+    await chainlink.next()
+    await product.settleAccount(user.address)
+
+    expect(await product.isLiquidating(user.address)).to.be.false
   })
 
   it('creates and resolves a shortfall', async () => {

--- a/packages/perennial/test/unit/product/Product.test.ts
+++ b/packages/perennial/test/unit/product/Product.test.ts
@@ -443,6 +443,31 @@ describe('Product', () => {
         expect(await product['latestVersion(address)'](user.address)).to.equal(3)
       })
 
+      it('opens the position with settle after liquidation', async () => {
+        await product.connect(user).openMake(POSITION)
+
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_2)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_2)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_2).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_2)
+
+        // Liquidate the user
+        await product.connect(collateralSigner).closeAll(user.address)
+        // User can't open a new position yet
+        await expect(product.connect(user).openMake(POSITION)).to.be.revertedWith('ProductInLiquidationError()')
+
+        // Advance version
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_3)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_3)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_3).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_3)
+
+        // Liquidation flag is cleared during settle flow
+        await expect(product.connect(user).openMake(POSITION))
+          .to.emit(product, 'MakeOpened')
+          .withArgs(user.address, 3, POSITION)
+      })
+
       it('reverts if oracle not bootstrapped', async () => {
         await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_0)
         await productProvider.mock.atVersion.withArgs(0).returns(ORACLE_VERSION_0)
@@ -1236,6 +1261,31 @@ describe('Product', () => {
           closePosition: { maker: 0, taker: 0 },
         })
         expect(await product['latestVersion(address)'](user.address)).to.equal(3)
+      })
+
+      it('opens the position with settle after liquidation', async () => {
+        await product.connect(user).openTake(POSITION)
+
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_2)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_2)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_2).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_2)
+
+        // Liquidate the user
+        await product.connect(collateralSigner).closeAll(user.address)
+        // User can't open a new position yet
+        await expect(product.connect(user).openTake(POSITION)).to.be.revertedWith('ProductInLiquidationError()')
+
+        // Advance version
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_3)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_3)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_3).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_3)
+
+        // Liquidation flag is cleared during settle flow
+        await expect(product.connect(user).openTake(POSITION))
+          .to.emit(product, 'TakeOpened')
+          .withArgs(user.address, 3, POSITION)
       })
 
       it('reverts if taker > maker', async () => {
@@ -2967,6 +3017,31 @@ describe('Product', () => {
         expect(await product['latestVersion(address)'](user.address)).to.equal(3)
       })
 
+      it('opens the position with settle after liquidation', async () => {
+        await product.connect(user).openMake(POSITION)
+
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_2)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_2)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_2).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_2)
+
+        // Liquidate the user
+        await product.connect(collateralSigner).closeAll(user.address)
+        // User can't open a new position yet
+        await expect(product.connect(user).openMake(POSITION)).to.be.revertedWith('ProductInLiquidationError()')
+
+        // Advance version
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_3)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_3)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_3).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_3)
+
+        // Liquidation flag is cleared during settle flow
+        await expect(product.connect(user).openMake(POSITION))
+          .to.emit(product, 'MakeOpened')
+          .withArgs(user.address, 3, POSITION)
+      })
+
       it('reverts if oracle not bootstrapped', async () => {
         await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_0)
         await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_0)
@@ -3755,6 +3830,31 @@ describe('Product', () => {
           closePosition: { maker: 0, taker: 0 },
         })
         expect(await product['latestVersion(address)'](user.address)).to.equal(3)
+      })
+
+      it('opens the position with settle after liquidation', async () => {
+        await product.connect(user).openTake(POSITION)
+
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_2)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_2)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_2).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_2)
+
+        // Liquidate the user
+        await product.connect(collateralSigner).closeAll(user.address)
+        // User can't open a new position yet
+        await expect(product.connect(user).openTake(POSITION)).to.be.revertedWith('ProductInLiquidationError()')
+
+        // Advance version
+        await productProvider.mock.currentVersion.withArgs().returns(ORACLE_VERSION_3)
+        await productProvider.mock.atVersion.withArgs(2).returns(ORACLE_VERSION_3)
+        await incentivizer.mock.sync.withArgs(ORACLE_VERSION_3).returns()
+        await productProvider.mock.sync.withArgs().returns(ORACLE_VERSION_3)
+
+        // Liquidation flag is cleared during settle flow
+        await expect(product.connect(user).openTake(POSITION))
+          .to.emit(product, 'TakeOpened')
+          .withArgs(user.address, 3, POSITION)
       })
 
       it('reverts if can liquidate', async () => {


### PR DESCRIPTION
When a user gets liquidated, we set the `AccountPosition.liquidation` flag to `true`. However, we never set this flag to `false` so after a liquidation the user can never open a new position. The fix is to clear the flag the next time the position is settled in `AccountPosition.settle`

Also added both unit and integration tests.