### PR TITLE
[Partial Fix] L08 - Missing isProduct modifier may lead to unexpected behavior.

### DIFF
--- a/packages/perennial/contracts/collateral/Collateral.sol
+++ b/packages/perennial/contracts/collateral/Collateral.sol
@@ -213,7 +213,7 @@ contract Collateral is ICollateral, UInitializable, UControllerProvider, UReentr
      * @param product Product to resolve shortfall for
      * @param amount Amount of shortfall to resolve
      */
-    function resolveShortfall(IProduct product, UFixed18 amount) external notPausedProduct(product) {
+    function resolveShortfall(IProduct product, UFixed18 amount) external isProduct(product) notPausedProduct(product) {
         _products[product].resolve(amount);
         token.pull(msg.sender, amount);
 


### PR DESCRIPTION
Only adds the modifier to `resolveShortfall` as the other increase gas cost by a non-negligible amount due to external calls

`Collateral.depositTo` and `Collateral.liquidate` increased by 3k
`Product.openMake` and `Product.openTake` increased by 9k

These gas costs aren't worth the savings, as the functions would revert elsewhere instead.