### PR TITLE
Fix prepack command to remove all .dbg.json files

### DIFF
--- a/packages/perennial-examples/package.json
+++ b/packages/perennial-examples/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf cache artifacts types/generated dist deployments/localhost",
     "node:fork:kovan": "FORK_ENABLED=true FORK_NETWORK=kovan NODE_INTERVAL_MINING=500 hardhat node",
     "deploy:fork:kovan": "FORK_ENABLED=true FORK_NETWORK=kovan hardhat deploy --network localhost",
-    "prepack": "yarn build && rm -rf artifacts/contracts/**/**/*.dbg.json"
+    "prepack": "yarn build && find artifacts/contracts -name '*.dbg.json' -type f -delete"
   },
   "author": "",
   "license": "APACHE-2.0",

--- a/packages/perennial-oracle/package.json
+++ b/packages/perennial-oracle/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf cache artifacts types/generated dist deployments/localhost",
     "node:fork:kovan": "FORK_ENABLED=true FORK_NETWORK=kovan NODE_INTERVAL_MINING=500 hardhat node",
     "deploy:fork:kovan": "FORK_ENABLED=true FORK_NETWORK=kovan hardhat deploy --network localhost",
-    "prepack": "yarn build && rm -rf artifacts/contracts/**/**/*.dbg.json"
+    "prepack": "yarn build && find artifacts/contracts -name '*.dbg.json' -type f -delete"
   },
   "author": "",
   "license": "APACHE-2.0",

--- a/packages/perennial/package.json
+++ b/packages/perennial/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf cache artifacts types/generated deployments/localhost",
     "node:fork:kovan": "FORK_ENABLED=true FORK_NETWORK=kovan NODE_INTERVAL_MINING=500 hardhat node",
     "deploy:fork:kovan": "FORK_ENABLED=true FORK_NETWORK=kovan hardhat deploy --network localhost",
-    "prepack": "yarn build && rm -rf artifacts/contracts/**/**/*.dbg.json"
+    "prepack": "yarn build && find artifacts/contracts -name '*.dbg.json' -type f -delete"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The previous command wasn't removing all the `.dbg.json` files, this one does to make our published package cleaner.