### PR TITLE
[Fix] B01 - Fix interface variable names for ICollateral

### DIFF
--- a/packages/perennial/contracts/interfaces/ICollateral.sol
+++ b/packages/perennial/contracts/interfaces/ICollateral.sol
@@ -25,8 +25,8 @@ interface ICollateral {
     function fees(address account) external view returns (UFixed18);
     function initialize(IController controller_) external;
     function depositTo(address account, IProduct product, UFixed18 amount) external;
-    function withdrawTo(address account, IProduct product, UFixed18 amount) external;
-    function withdrawFrom(address from, address account, IProduct product, UFixed18 amount) external;
+    function withdrawTo(address receiver, IProduct product, UFixed18 amount) external;
+    function withdrawFrom(address account, address receiver, IProduct product, UFixed18 amount) external;
     function liquidate(address account, IProduct product) external;
     function settleAccount(address account, Fixed18 amount) external;
     function settleProduct(UFixed18 amount) external;


### PR DESCRIPTION
When working on the docs I realized that the `withdraw` variable names in `ICollateral` did not match `Collateral`