### PR TITLE
[Fix] B02 - Revert Controller 'initialize' changes

### DIFF
--- a/packages/perennial/contracts/controller/Controller.sol
+++ b/packages/perennial/contracts/controller/Controller.sol
@@ -77,20 +77,17 @@ contract Controller is IController, UInitializable {
      * @param collateral_ Collateral contract address
      * @param incentivizer_ Incentivizer contract address
      * @param productBeacon_ Product implementation beacon address
-     * @param multiInvoker_ MultiINvoker contract address
      */
     function initialize(
         ICollateral collateral_,
         IIncentivizer incentivizer_,
-        IBeacon productBeacon_,
-        IMultiInvoker multiInvoker_
+        IBeacon productBeacon_
     ) external initializer(1) {
         _createCoordinator();
 
         updateCollateral(collateral_);
         updateIncentivizer(incentivizer_);
         updateProductBeacon(productBeacon_);
-        updateMultiInvoker(multiInvoker_);
     }
 
     /**

--- a/packages/perennial/contracts/interfaces/IController.sol
+++ b/packages/perennial/contracts/interfaces/IController.sol
@@ -64,7 +64,7 @@ interface IController {
     function programsPerProduct() external view returns (uint256);
     function pauser() external view returns (address);
     function paused() external view returns (bool);
-    function initialize(ICollateral collateral_, IIncentivizer incentivizer_, IBeacon productBeacon_, IMultiInvoker mulltiinvoker_) external;
+    function initialize(ICollateral collateral_, IIncentivizer incentivizer_, IBeacon productBeacon_) external;
     function createCoordinator() external returns (uint256);
     function updateCoordinatorPendingOwner(uint256 coordinatorId, address newPendingOwner) external;
     function acceptCoordinatorOwner(uint256 coordinatorId) external;

--- a/packages/perennial/deploy/002_deploy_core.ts
+++ b/packages/perennial/deploy/002_deploy_core.ts
@@ -178,9 +178,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log('Controller already initialized.')
   } else {
     process.stdout.write('initializing Controller... ')
-    await (
-      await controller.initialize(collateral.address, incentivizer.address, productBeacon.address, multiInvoker.address)
-    ).wait(2)
+    await (await controller.initialize(collateral.address, incentivizer.address, productBeacon.address)).wait(2)
+    process.stdout.write('complete.\n')
+  }
+
+  if ((await controller.multiInvoker()) === multiInvoker.address) {
+    console.log('Controller MutliInvoker already set.')
+  } else {
+    process.stdout.write('setting Controller MultiInvoker... ')
+    await (await controller.updateMultiInvoker(multiInvoker.address)).wait(2)
     process.stdout.write('complete.\n')
   }
 

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -135,7 +135,7 @@ export async function deployProtocol(): Promise<InstanceVars> {
 
   // Init
   await incentivizer.initialize(controller.address)
-  await controller.initialize(collateral.address, incentivizer.address, productBeacon.address, multiInvoker.address)
+  await controller.initialize(collateral.address, incentivizer.address, productBeacon.address)
   await collateral.initialize(controller.address)
   await multiInvoker.initialize(controller.address)
 
@@ -148,6 +148,7 @@ export async function deployProtocol(): Promise<InstanceVars> {
   await controller.updateIncentivizationFee(utils.parseEther('0.00'))
   await controller.updateMinCollateral(utils.parseEther('500'))
   await controller.updateProgramsPerProduct(2)
+  await controller.updateMultiInvoker(multiInvoker.address)
 
   // Set state
   const dsuHolder = await impersonate.impersonateWithBalance(DSU_HOLDER, utils.parseEther('10'))

--- a/packages/perennial/test/unit/controller/Controller.test.ts
+++ b/packages/perennial/test/unit/controller/Controller.test.ts
@@ -63,7 +63,8 @@ describe('Controller', () => {
     await productBeacon.mock.implementation.withArgs().returns(productImpl.address)
 
     controller = await new Controller__factory(owner).deploy()
-    await controller.initialize(collateral.address, incentivizer.address, productBeacon.address, multiInvoker.address)
+    await controller.initialize(collateral.address, incentivizer.address, productBeacon.address)
+    await controller.updateMultiInvoker(multiInvoker.address)
   })
 
   describe('#initialize', async () => {
@@ -96,7 +97,7 @@ describe('Controller', () => {
 
     it('reverts if already initialized', async () => {
       await expect(
-        controller.initialize(collateral.address, incentivizer.address, productBeacon.address, multiInvoker.address),
+        controller.initialize(collateral.address, incentivizer.address, productBeacon.address),
       ).to.be.revertedWith('UInitializableAlreadyInitializedError(1)')
     })
   })


### PR DESCRIPTION
Reverts `Controller` initializer changes to keep this more straightforward for the first deployment. I confirmed that an `address(0)` MultiInvoker is safe (only used [here](https://github.com/equilibria-xyz/perennial-mono/blob/2fc5c594797a0d2ae23cbd83caa269cbd60c0e5a/packages/perennial/contracts/controller/UControllerProvider.sol#L75) which checks if the `msg.sender` is equal to the multiinvoker, which is impossible for the null address)