### PR TITLE
Move MultiInvoker addresses to immutable

### DIFF
--- a/packages/perennial/contracts/interfaces/IMultiInvoker.sol
+++ b/packages/perennial/contracts/interfaces/IMultiInvoker.sol
@@ -5,6 +5,7 @@ import "@equilibria/root/token/types/Token6.sol";
 import "@equilibria/emptyset-batcher/batcher/Batcher.sol";
 
 import "./IController.sol";
+import "./ICollateral.sol";
 import "./IProduct.sol";
 
 interface IMultiInvoker {
@@ -30,8 +31,12 @@ interface IMultiInvoker {
         bytes args;
     }
 
-    function initialize(IController controller_) external;
+    function initialize() external;
     function USDC() external view returns (Token6); // solhint-disable-line func-name-mixedcase
+    function DSU() external view returns (Token18); // solhint-disable-line func-name-mixedcase
     function batcher() external view returns (Batcher);
+    function controller() external view returns (IController);
+    function collateral() external view returns (ICollateral);
+    function reserve() external view returns (IEmptySetReserve);
     function invoke(Invocation[] calldata invocations) external;
 }

--- a/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
+++ b/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
@@ -4,45 +4,53 @@ pragma solidity 0.8.15;
 import "hardhat/console.sol";
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 
-import "../controller/UControllerProvider.sol";
-import "../interfaces/IProduct.sol";
-import "../interfaces/ICollateral.sol";
 import "../interfaces/IMultiInvoker.sol";
 
-contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
+contract MultiInvoker is IMultiInvoker, UInitializable {
     /// @dev USDC stablecoin address
     Token6 public immutable USDC; // solhint-disable-line var-name-mixedcase
 
+    /// @dev DSU address
+    Token18 public immutable DSU; // solhint-disable-line var-name-mixedcase
+
     /// @dev Batcher address
     Batcher public immutable batcher;
+
+    /// @dev Controller address
+    IController public immutable controller;
+
+    /// @dev Collateral address
+    ICollateral public immutable collateral;
+
+    /// @dev Reserve address
+    IEmptySetReserve public immutable reserve;
 
     /**
      * @notice Initializes the immutable contract state
      * @dev Called at implementation instantiate and constant for that implementation.
      * @param usdc_ USDC stablecoin address
      * @param batcher_ Protocol Batcher address
+     * @param controller_ Protocol Controller address
      */
-    constructor(Token6 usdc_, Batcher batcher_) {
+    constructor(Token6 usdc_, Batcher batcher_, IController controller_) {
         USDC = usdc_;
         batcher = batcher_;
+        controller = controller_;
+        collateral = controller.collateral();
+        DSU = collateral.token();
+        reserve = batcher.RESERVE();
     }
 
     /**
      * @notice Initializes the contract state
      * @dev Must be called atomically as part of the upgradeable proxy deployment to
      *      avoid front-running
-     * @param controller_ Controller contract address
      */
-    function initialize(IController controller_) external initializer(1) {
-        __UControllerProvider__initialize(controller_);
-
-        ICollateral _collateral = controller().collateral();
-        Token18 token = _collateral.token();
-        address reserve = address(batcher.RESERVE());
-        token.approve(address(_collateral));
-        token.approve(reserve);
+    function initialize() external initializer(1) {
+        DSU.approve(address(collateral));
+        DSU.approve(address(reserve));
         USDC.approve(address(batcher));
-        USDC.approve(reserve);
+        USDC.approve(address(reserve));
     }
 
     /**
@@ -61,7 +69,7 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
             // Withdraw from `msg.sender`s `product` collateral account to `receiver`
             } else if (invocation.action == PerennialAction.WITHDRAW) {
                 (address receiver, IProduct product, UFixed18 amount) = abi.decode(invocation.args, (address, IProduct, UFixed18));
-                controller().collateral().withdrawFrom(msg.sender, receiver, product, amount);
+                collateral.withdrawFrom(msg.sender, receiver, product, amount);
 
             // Open a take position on behalf of `msg.sender`
             } else if (invocation.action == PerennialAction.OPEN_TAKE) {
@@ -86,7 +94,7 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
             // Claim `msg.sender`s incentive reward for `product` programs
             } else if (invocation.action == PerennialAction.CLAIM) {
                 (IProduct product, uint256[] memory programIds) = abi.decode(invocation.args, (IProduct, uint256[]));
-                controller().incentivizer().claimFor(msg.sender, product, programIds);
+                controller.incentivizer().claimFor(msg.sender, product, programIds);
 
             // Wrap `msg.sender`s USDC into DSU and return the DSU to `account`
             } else if (invocation.action == PerennialAction.WRAP) {
@@ -119,13 +127,11 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
      * @param amount Amount of DSU to deposit into the collateral account
      */
     function depositTo(address account, IProduct product, UFixed18 amount) private {
-        ICollateral _collateral = controller().collateral();
-
         // Pull the token from the `msg.sender`
-        _collateral.token().pull(msg.sender, amount);
+        DSU.pull(msg.sender, amount);
 
         // Deposit the amount to the collateral account
-        _collateral.depositTo(account, product, amount);
+        collateral.depositTo(account, product, amount);
     }
 
     /**
@@ -137,7 +143,7 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
         // Pull USDC from the `msg.sender`
         USDC.pull(msg.sender, amount, true);
 
-        _wrap(controller().collateral().token(), receiver, amount);
+        _wrap(receiver, amount);
     }
 
     /**
@@ -147,7 +153,7 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
      */
     function unwrap(address receiver, UFixed18 amount) private {
         // Pull the token from the `msg.sender`
-        controller().collateral().token().pull(msg.sender, amount);
+        DSU.pull(msg.sender, amount);
 
         _unwrap(receiver, amount);
     }
@@ -162,11 +168,10 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
         // Pull USDC from the `msg.sender`
         USDC.pull(msg.sender, amount, true);
 
-        ICollateral _collateral = controller().collateral();
-        _wrap(_collateral.token(), address(this), amount);
+        _wrap(address(this), amount);
 
         // Deposit the amount to the collateral account
-        _collateral.depositTo(account, product, amount);
+        collateral.depositTo(account, product, amount);
     }
 
     /**
@@ -177,22 +182,21 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
      */
     function withdrawAndUnwrap(address receiver, IProduct product, UFixed18 amount) private {
         // Withdraw the amount from the collateral account
-        controller().collateral().withdrawFrom(msg.sender, address(this), product, amount);
+        collateral.withdrawFrom(msg.sender, address(this), product, amount);
 
         _unwrap(receiver, amount);
     }
 
     /**
      * @notice Helper function to wrap `amount` USDC from `msg.sender` into DSU using the batcher or reserve
-     * @param token DSU token address
      * @param receiver Address to receive the DSU
      * @param amount Amount of USDC to wrap
      */
-    function _wrap(Token18 token, address receiver, UFixed18 amount) private {
+    function _wrap(address receiver, UFixed18 amount) private {
         // If the batcher doesn't have enough for this wrap, go directly to the reserve
-        if (amount.gt(token.balanceOf(address(batcher)))) {
-            batcher.RESERVE().mint(amount);
-            if (receiver != address(this)) token.push(receiver, amount);
+        if (amount.gt(DSU.balanceOf(address(batcher)))) {
+            reserve.mint(amount);
+            if (receiver != address(this)) DSU.push(receiver, amount);
         } else {
             // Wrap the USDC into DSU and return to the receiver
             batcher.wrap(amount, receiver);
@@ -207,7 +211,7 @@ contract MultiInvoker is IMultiInvoker, UInitializable, UControllerProvider {
     function _unwrap(address receiver, UFixed18 amount) private {
         // Unwrap the DSU into USDC and return to the receiver
         // The current batcher does not have UNWRAP functionality yet, so just go directly to the reserve
-        batcher.RESERVE().redeem(amount);
+        reserve.redeem(amount);
 
         // Push the amount to the receiver
         USDC.push(receiver, amount);

--- a/packages/perennial/deploy/002_deploy_core.ts
+++ b/packages/perennial/deploy/002_deploy_core.ts
@@ -38,6 +38,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log('using Batcher address: ' + batcherAddress)
   console.log('using Multisig address: ' + multisigAddress)
 
+  const dsu = await IERC20__factory.connect(dsuAddress, deployerSigner)
+
   // IMPLEMENTATIONS
 
   const collateralImpl: Deployment = await deploy('Collateral_Impl', {
@@ -184,11 +186,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     process.stdout.write('complete.\n')
   }
 
-  if ((await multiInvoker.controller()) === controller.address) {
+  if ((await dsu.callStatic.allowance(multiInvoker.address, batcherAddress)).eq(ethers.constants.MaxUint256)) {
     console.log('MultiInvoker already initialized.')
   } else {
     process.stdout.write('initializing MultiInvoker... ')
-    await (await multiInvoker.initialize(controller.address)).wait(2)
+    await (await multiInvoker.initialize()).wait(2)
     process.stdout.write('complete.\n')
   }
 

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -102,7 +102,6 @@ export async function deployProtocol(): Promise<InstanceVars> {
   const controllerImpl = await new Controller__factory(owner).deploy()
   const incentivizerImpl = await new Incentivizer__factory(owner).deploy()
   const collateralImpl = await new Collateral__factory(owner).deploy(dsu.address)
-  const multiInvokerImpl = await new MultiInvoker__factory(owner).deploy(usdc.address, batcher.address)
 
   const controllerProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
     controllerImpl.address,
@@ -114,11 +113,7 @@ export async function deployProtocol(): Promise<InstanceVars> {
     proxyAdmin.address,
     [],
   )
-  const multiInvokerProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
-    multiInvokerImpl.address,
-    proxyAdmin.address,
-    [],
-  )
+
   const collateralProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
     collateralImpl.address,
     proxyAdmin.address,
@@ -131,13 +126,25 @@ export async function deployProtocol(): Promise<InstanceVars> {
 
   const productImpl = await new Product__factory(owner).deploy()
   const productBeacon = await new UpgradeableBeacon__factory(owner).deploy(productImpl.address)
-  const multiInvoker = await new MultiInvoker__factory(owner).attach(multiInvokerProxy.address)
 
   // Init
   await incentivizer.initialize(controller.address)
-  await controller.initialize(collateral.address, incentivizer.address, productBeacon.address, multiInvoker.address)
+  await controller.initialize(collateral.address, incentivizer.address, productBeacon.address, productBeacon.address) // TODO(arjun): remove last arg when initializer revert is merged
   await collateral.initialize(controller.address)
-  await multiInvoker.initialize(controller.address)
+
+  // Setup MultiInvoker
+  const multiInvokerImpl = await new MultiInvoker__factory(owner).deploy(
+    usdc.address,
+    batcher.address,
+    controllerProxy.address,
+  )
+  const multiInvokerProxy = await new TransparentUpgradeableProxy__factory(owner).deploy(
+    multiInvokerImpl.address,
+    proxyAdmin.address,
+    [],
+  )
+  const multiInvoker = await new MultiInvoker__factory(owner).attach(multiInvokerProxy.address)
+  await multiInvoker.initialize()
 
   // Params - TODO: finalize before launch
   await controller.updatePauser(pauser.address)
@@ -148,6 +155,7 @@ export async function deployProtocol(): Promise<InstanceVars> {
   await controller.updateIncentivizationFee(utils.parseEther('0.00'))
   await controller.updateMinCollateral(utils.parseEther('500'))
   await controller.updateProgramsPerProduct(2)
+  await controller.updateMultiInvoker(multiInvoker.address)
 
   // Set state
   const dsuHolder = await impersonate.impersonateWithBalance(DSU_HOLDER, utils.parseEther('10'))

--- a/packages/perennial/test/integration/multiinvkoer/multiinvoker.test.ts
+++ b/packages/perennial/test/integration/multiinvkoer/multiinvoker.test.ts
@@ -16,6 +16,18 @@ describe('MultiInvoker', () => {
   })
 
   describe('#initialize', () => {
+    it('sets the correct contract addresses', async () => {
+      const { multiInvoker, usdc, dsu, batcher, controller, collateral } = instanceVars
+      const reserve = await batcher.RESERVE()
+
+      expect((await multiInvoker.USDC()).toLowerCase()).to.equal(usdc.address.toLowerCase())
+      expect((await multiInvoker.DSU()).toLowerCase()).to.equal(dsu.address.toLowerCase())
+      expect((await multiInvoker.batcher()).toLowerCase()).to.equal(batcher.address.toLowerCase())
+      expect((await multiInvoker.controller()).toLowerCase()).to.equal(controller.address.toLowerCase())
+      expect((await multiInvoker.collateral()).toLowerCase()).to.equal(collateral.address.toLowerCase())
+      expect((await multiInvoker.reserve()).toLowerCase()).to.equal(reserve.toLowerCase())
+    })
+
     it('sets the correct approvals', async () => {
       const { multiInvoker, usdc, dsu, batcher, collateral } = instanceVars
 
@@ -26,7 +38,7 @@ describe('MultiInvoker', () => {
     })
 
     it('reverts if already initialized', async () => {
-      await expect(instanceVars.multiInvoker.initialize(instanceVars.controller.address)).to.be.revertedWith(
+      await expect(instanceVars.multiInvoker.initialize()).to.be.revertedWith(
         'UInitializableAlreadyInitializedError(1)',
       )
     })

--- a/packages/perennial/test/unit/multiinvoker/MultiInvoker.test.ts
+++ b/packages/perennial/test/unit/multiinvoker/MultiInvoker.test.ts
@@ -52,7 +52,7 @@ describe('MultiInvoker', () => {
     batcher.RESERVE.returns(reserve.address)
     batcher.DSU.returns(dsu.address)
 
-    multiInvoker = await new MultiInvoker__factory(owner).deploy(usdc.address, batcher.address)
+    multiInvoker = await new MultiInvoker__factory(owner).deploy(usdc.address, batcher.address, controller.address)
 
     dsu.allowance.whenCalledWith(multiInvoker.address, collateral.address).returns(0)
     dsu.approve.whenCalledWith(collateral.address, ethers.constants.MaxUint256).returns(true)
@@ -67,20 +67,22 @@ describe('MultiInvoker', () => {
     usdc.allowance.whenCalledWith(multiInvoker.address, reserve.address).returns(0)
     usdc.approve.whenCalledWith(reserve.address, ethers.constants.MaxUint256).returns(true)
 
-    await multiInvoker.initialize(controller.address)
+    await multiInvoker.initialize()
   })
 
   describe('#constructor', () => {
     it('constructs correctly', async () => {
       expect((await multiInvoker.USDC()).toLowerCase()).to.equal(usdc.address.toLowerCase())
+      expect((await multiInvoker.DSU()).toLowerCase()).to.equal(dsu.address.toLowerCase())
       expect((await multiInvoker.batcher()).toLowerCase()).to.equal(batcher.address.toLowerCase())
+      expect((await multiInvoker.controller()).toLowerCase()).to.equal(controller.address.toLowerCase())
+      expect((await multiInvoker.collateral()).toLowerCase()).to.equal(collateral.address.toLowerCase())
+      expect((await multiInvoker.reserve()).toLowerCase()).to.equal(reserve.address.toLowerCase())
     })
   })
 
   describe('#initialize', () => {
     it('initializes correctly', async () => {
-      expect((await multiInvoker.controller()).toLowerCase()).to.equal(controller.address.toLowerCase())
-
       expect(dsu.approve).to.be.calledWith(collateral.address, ethers.constants.MaxUint256)
       expect(dsu.approve).to.be.calledWith(reserve.address, ethers.constants.MaxUint256)
       expect(usdc.approve).to.be.calledWith(batcher.address, ethers.constants.MaxUint256)


### PR DESCRIPTION
Makes `controller`, `collateral`, `DSU`, and `reserve` immutable on the MultiInvoker for gas savings.