### PR TITLE
Prevent withdrawals if user is in liquidation

### DIFF
--- a/packages/perennial/contracts/collateral/Collateral.sol
+++ b/packages/perennial/contracts/collateral/Collateral.sol
@@ -92,6 +92,8 @@ contract Collateral is ICollateral, UInitializable, UControllerProvider, UReentr
     collateralInvariant(account, product)
     maintenanceInvariant(account, product)
     {
+        if (product.isLiquidating(account)) revert CollateralAccountLiquidatingError(account);
+
         amount = amount.eq(UFixed18Lib.MAX) ? collateral(account, product) : amount;
         _products[product].debitAccount(account, amount);
         token.push(receiver, amount);

--- a/packages/perennial/contracts/interfaces/ICollateral.sol
+++ b/packages/perennial/contracts/interfaces/ICollateral.sol
@@ -20,6 +20,7 @@ interface ICollateral {
     error CollateralInsufficientCollateralError();
     error CollateralUnderLimitError();
     error CollateralZeroAddressError();
+    error CollateralAccountLiquidatingError(address account);
 
     function token() external view returns (Token18);
     function fees(address account) external view returns (UFixed18);

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -35,6 +35,9 @@ describe('Liquidate', () => {
       .withArgs(user.address, product.address, userB.address, utils.parseEther('1000'))
 
     expect(await product.isLiquidating(user.address)).to.be.true
+    await expect(collateral.connect(user).withdrawTo(user.address, product.address, constants.MaxUint256))
+      .to.be.revertedWithCustomError(collateral, 'CollateralAccountLiquidatingError')
+      .withArgs(user.address)
 
     expect(await collateral['collateral(address,address)'](user.address, product.address)).to.equal(0)
     expect(await collateral['collateral(address)'](product.address)).to.equal(0)
@@ -44,6 +47,8 @@ describe('Liquidate', () => {
     await product.settleAccount(user.address)
 
     expect(await product.isLiquidating(user.address)).to.be.false
+    await expect(collateral.connect(user).withdrawTo(user.address, product.address, constants.MaxUint256)).to.not.be
+      .reverted
   })
 
   it('creates and resolves a shortfall', async () => {

--- a/packages/perennial/test/unit/collateral/Collateral.test.ts
+++ b/packages/perennial/test/unit/collateral/Collateral.test.ts
@@ -155,6 +155,10 @@ describe('Collateral', () => {
       await product.mock.maintenance.withArgs(userB.address).returns(0)
       await product.mock.maintenanceNext.withArgs(userB.address).returns(0)
 
+      // Mock isLiquidating calls
+      await product.mock.isLiquidating.withArgs(user.address).returns(false)
+      await product.mock.isLiquidating.withArgs(userB.address).returns(false)
+
       //Pre-fill account
       await token.mock.transferFrom.withArgs(owner.address, collateral.address, 100).returns(true)
       await collateral.connect(owner).depositTo(user.address, product.address, 100)
@@ -230,6 +234,14 @@ describe('Collateral', () => {
             collateral,
             'CollateralInsufficientCollateralError',
           )
+        })
+
+        it('reverts if in liquidation', async () => {
+          await product.mock.isLiquidating.withArgs(user.address).returns(true)
+
+          await expect(fn(user.address, product.address, 80))
+            .to.be.revertedWithCustomError(collateral, 'CollateralAccountLiquidatingError')
+            .withArgs(user.address)
         })
 
         describe('multiple users per product', async () => {


### PR DESCRIPTION
If a user is in liquidation, they were previously able to withdraw all of their collateral due to their `maintenance` being forced to `0`. This prevents any withdrawals while the user is being liquidated.