### PR TITLE
Use minCollateral in Liquidate is maintenance < minCollateral

### DIFF
--- a/packages/perennial/contracts/collateral/Collateral.sol
+++ b/packages/perennial/contracts/collateral/Collateral.sol
@@ -122,7 +122,9 @@ contract Collateral is ICollateral, UInitializable, UControllerProvider, UReentr
 
         // claim fee
         UFixed18 liquidationFee = controller().liquidationFee();
-        UFixed18 fee = UFixed18Lib.min(totalCollateral, totalMaintenance.mul(liquidationFee));
+        // If maintenance is less than minCollateral, use minCollateral for fee amount
+        UFixed18 collateralForFee = UFixed18Lib.max(totalMaintenance, controller().minCollateral());
+        UFixed18 fee = UFixed18Lib.min(totalCollateral, collateralForFee.mul(liquidationFee));
 
         _products[product].debitAccount(account, fee);
         token.push(msg.sender, fee);

--- a/packages/perennial/test/integration/core/liquidate.test.ts
+++ b/packages/perennial/test/integration/core/liquidate.test.ts
@@ -77,7 +77,7 @@ describe('Liquidate', () => {
 
     expect(await collateral['collateral(address,address)'](user.address, product.address)).to.equal(0)
     expect(await collateral['collateral(address)'](product.address)).to.equal(0)
-    expect(await dsu.balanceOf(userB.address)).to.equal(utils.parseEther('2100')) // Original 20000 + fee
+    expect(await dsu.balanceOf(userB.address)).to.equal(utils.parseEther('21000')) // Original 20000 + fee
 
     await chainlink.next()
     await product.settleAccount(user.address)

--- a/packages/perennial/test/unit/collateral/Collateral.test.ts
+++ b/packages/perennial/test/unit/collateral/Collateral.test.ts
@@ -422,6 +422,22 @@ describe('Collateral', () => {
         expect(await collateral['collateral(address)'](product.address)).to.equal(50)
       })
 
+      it('calculates fee on minCollateral if maintenance < minCollateral', async () => {
+        await controller.mock.minCollateral.returns(120)
+        await product.mock.maintenance.withArgs(user.address).returns(101)
+        await product.mock.closeAll.withArgs(user.address).returns()
+        await token.mock.transfer.withArgs(owner.address, 60).returns(true)
+
+        expect(await collateral.liquidatable(user.address, product.address)).to.equal(true)
+
+        await expect(collateral.liquidate(user.address, product.address))
+          .to.emit(collateral, 'Liquidation')
+          .withArgs(user.address, product.address, owner.address, 60)
+
+        expect(await collateral['collateral(address,address)'](user.address, product.address)).to.equal(40)
+        expect(await collateral['collateral(address)'](product.address)).to.equal(40)
+      })
+
       it('limits fee to total collateral', async () => {
         await product.mock.maintenance.withArgs(user.address).returns(210)
         await product.mock.closeAll.withArgs(user.address).returns()


### PR DESCRIPTION
If the user's maintenance is less than `minCollateral`, then use `minCollateral` for liquidation calculation 