### PR TITLE
Remove incorrect dev doc for createCoordinator

### DIFF
--- a/packages/perennial/contracts/controller/Controller.sol
+++ b/packages/perennial/contracts/controller/Controller.sol
@@ -92,7 +92,6 @@ contract Controller is IController, UInitializable {
 
     /**
      * @notice Creates a new coordinator with `msg.sender` as the owner
-     * @dev Can only be called by the protocol owner
      * @return New coordinator ID
      */
     function createCoordinator() external returns (uint256) {


### PR DESCRIPTION
The `createCoordinator` function can be called by anyone, however the dev doc incorrectly states that it is access controlled.