### PR TITLE
Bug Fix: StartingVersionForPhaseId contains incorrect values

### DIFF
--- a/packages/perennial-oracle/contracts/ChainlinkOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkOracle.sol
@@ -56,7 +56,8 @@ contract ChainlinkOracle is IOracleProvider {
         // Update phase annotation when new phase detected
         while (round.phaseId() > _latestPhaseId()) {
             uint256 roundCount = registry.getRoundCount(base, quote, _latestPhaseId());
-            _startingVersionForPhaseId.push(roundCount);
+            _startingVersionForPhaseId.push(
+                roundCount + _startingVersionForPhaseId[_startingVersionForPhaseId.length - 1]);
         }
 
         // Return packaged oracle version
@@ -106,7 +107,7 @@ contract ChainlinkOracle is IOracleProvider {
 
     /**
      * @notice Computes the chainlink round ID from a version
-     * @notice version Version to compute from
+     * @param version Version to compute from
      * @return Chainlink round ID
      */
     function _versionToRoundId(uint256 version) private view returns (uint80) {

--- a/packages/perennial-oracle/contracts/ChainlinkOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkOracle.sol
@@ -26,8 +26,13 @@ contract ChainlinkOracle is IOracleProvider {
     /// @dev Decimal offset used to normalize chainlink price to 18 decimals
     int256 private immutable _decimalOffset;
 
-    /// @dev Mapping of the first oracle version for each underlying phase ID
-    uint256[] private _startingVersionForPhaseId;
+    /// @dev Mapping of the starting data for each underlying phase
+    Phase[] private _phases;
+
+    struct Phase {
+        uint128 startingVersion;
+        uint128 startingRoundId;
+    }
 
     /**
      * @notice Initializes the contract state
@@ -40,8 +45,11 @@ contract ChainlinkOracle is IOracleProvider {
         base = base_;
         quote = quote_;
 
-        _startingVersionForPhaseId.push(0); // phaseId is 1-indexed, skip index 0
-        _startingVersionForPhaseId.push(0); // phaseId is 1-indexed, first phase starts as version 0
+        // phaseId is 1-indexed, skip index 0
+        _phases.push(Phase(uint128(0), uint128(0)));
+        // phaseId is 1-indexed, first phase starts as version 0
+        _phases.push(Phase(uint128(0), uint128(registry_.getStartingRoundId(base_, quote_, 1))));
+
         _decimalOffset = SafeCast.toInt256(10 ** registry_.decimals(base, quote));
     }
 
@@ -55,9 +63,13 @@ contract ChainlinkOracle is IOracleProvider {
 
         // Update phase annotation when new phase detected
         while (round.phaseId() > _latestPhaseId()) {
-            uint256 roundCount = registry.getRoundCount(base, quote, _latestPhaseId());
-            _startingVersionForPhaseId.push(
-                roundCount + _startingVersionForPhaseId[_startingVersionForPhaseId.length - 1]);
+            _phases.push(
+                Phase(
+                    uint128(registry.getRoundCount(base, quote, _latestPhaseId())) +
+                        _phases[_phases.length - 1].startingVersion,
+                    uint128(registry.getStartingRoundId(base, quote, _latestPhaseId()))
+                )
+            );
         }
 
         // Return packaged oracle version
@@ -88,8 +100,8 @@ contract ChainlinkOracle is IOracleProvider {
      * @return Built oracle version
      */
     function _buildOracleVersion(ChainlinkRound memory round) private view returns (OracleVersion memory) {
-        uint256 version = _startingVersionForPhaseId[round.phaseId()] +
-            uint256(round.roundId - registry.getStartingRoundId(base, quote, round.phaseId()));
+        Phase memory phase = _phases[round.phaseId()];
+        uint256 version = uint256(phase.startingVersion) + round.roundId - uint256(phase.startingRoundId);
         return _buildOracleVersion(round, version);
     }
 
@@ -110,21 +122,22 @@ contract ChainlinkOracle is IOracleProvider {
      * @param version Version to compute from
      * @return Chainlink round ID
      */
-    function _versionToRoundId(uint256 version) private view returns (uint80) {
-        uint16 phaseId = _versionToPhaseId(version);
-        return registry.getStartingRoundId(base, quote, phaseId) +
-            uint80(version - _startingVersionForPhaseId[phaseId]);
+    function _versionToRoundId(uint256 version) private view returns (uint256) {
+        Phase memory phase = _versionToPhase(version);
+        return uint256(phase.startingRoundId) + version - uint256(phase.startingVersion);
     }
 
     /**
      * @notice Computes the chainlink phase ID from a version
      * @param version Version to compute from
-     * @return phaseId Chainlink phase ID
+     * @return phase Chainlink phase
      */
-    function _versionToPhaseId(uint256 version) private view returns (uint16 phaseId) {
-        phaseId = _latestPhaseId();
-        while (_startingVersionForPhaseId[phaseId] > version) {
+    function _versionToPhase(uint256 version) private view returns (Phase memory phase) {
+        uint256 phaseId = _latestPhaseId();
+        phase = _phases[phaseId];
+        while (uint256(phase.startingVersion) > version) {
             phaseId--;
+            phase = _phases[phaseId];
         }
     }
 
@@ -133,6 +146,6 @@ contract ChainlinkOracle is IOracleProvider {
      * @return Latest seen phase ID
      */
     function _latestPhaseId() private view returns (uint16) {
-        return uint16(_startingVersionForPhaseId.length - 1);
+        return uint16(_phases.length - 1);
     }
 }

--- a/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
@@ -45,9 +45,9 @@ library ChainlinkRegistryLib {
      * @param roundId The specific round to fetch data for
      * @return Specific round's data
      */
-    function getRound(ChainlinkRegistry self, address base, address quote, uint80 roundId) internal view returns (ChainlinkRound memory) {
+    function getRound(ChainlinkRegistry self, address base, address quote, uint256 roundId) internal view returns (ChainlinkRound memory) {
         (, int256 answer, , uint256 updatedAt, ) =
-            FeedRegistryInterface(ChainlinkRegistry.unwrap(self)).getRoundData(base, quote, roundId);
+            FeedRegistryInterface(ChainlinkRegistry.unwrap(self)).getRoundData(base, quote, uint80(roundId));
         return ChainlinkRound({roundId: roundId, timestamp: updatedAt, answer: answer});
     }
 
@@ -74,10 +74,10 @@ library ChainlinkRegistryLib {
      * @param phaseId The specific phase to fetch data for
      * @return The quantity of rounds for the phase
      */
-    function getRoundCount(ChainlinkRegistry self, address base, address quote, uint16 phaseId)
-    internal view returns (uint80) {
+    function getRoundCount(ChainlinkRegistry self, address base, address quote, uint256 phaseId)
+    internal view returns (uint256) {
         (uint80 startingRoundId, uint80 endingRoundId) =
-            FeedRegistryInterface(ChainlinkRegistry.unwrap(self)).getPhaseRange(base, quote, phaseId);
-        return endingRoundId - startingRoundId + 1;
+            FeedRegistryInterface(ChainlinkRegistry.unwrap(self)).getPhaseRange(base, quote, uint16(phaseId));
+        return uint256(endingRoundId - startingRoundId + 1);
     }
 }

--- a/packages/perennial-oracle/contracts/types/ChainlinkRound.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkRound.sol
@@ -7,7 +7,7 @@ import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 struct ChainlinkRound {
     uint256 timestamp;
     int256 answer;
-    uint80 roundId;
+    uint256 roundId;
 }
 using ChainlinkRoundLib for ChainlinkRound global;
 

--- a/packages/perennial/contracts/collateral/Collateral.sol
+++ b/packages/perennial/contracts/collateral/Collateral.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/collateral/types/OptimisticLedger.sol
+++ b/packages/perennial/contracts/collateral/types/OptimisticLedger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 

--- a/packages/perennial/contracts/controller/Controller.sol
+++ b/packages/perennial/contracts/controller/Controller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";

--- a/packages/perennial/contracts/controller/UControllerProvider.sol
+++ b/packages/perennial/contracts/controller/UControllerProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/storage/UStorage.sol";

--- a/packages/perennial/contracts/forwarder/Forwarder.sol
+++ b/packages/perennial/contracts/forwarder/Forwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "../interfaces/IForwarder.sol";
 

--- a/packages/perennial/contracts/incentivizer/Incentivizer.sol
+++ b/packages/perennial/contracts/incentivizer/Incentivizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/incentivizer/types/ProductManager.sol
+++ b/packages/perennial/contracts/incentivizer/types/ProductManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./Program.sol";

--- a/packages/perennial/contracts/incentivizer/types/Program.sol
+++ b/packages/perennial/contracts/incentivizer/types/Program.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../interfaces/types/ProgramInfo.sol";
 

--- a/packages/perennial/contracts/interfaces/IForwarder.sol
+++ b/packages/perennial/contracts/interfaces/IForwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/token/types/Token18.sol";
 import "@equilibria/root/token/types/Token6.sol";

--- a/packages/perennial/contracts/interfaces/IMultiInvoker.sol
+++ b/packages/perennial/contracts/interfaces/IMultiInvoker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/token/types/Token6.sol";
 import "@equilibria/root/token/types/Token18.sol";

--- a/packages/perennial/contracts/interfaces/IParamProvider.sol
+++ b/packages/perennial/contracts/interfaces/IParamProvider.sol
@@ -20,10 +20,7 @@ interface IParamProvider {
         uint256 version
     );
 
-    error ParamProviderInvalidMakerFee();
-    error ParamProviderInvalidTakerFee();
-    error ParamProviderInvalidPositionFee();
-    error ParamProviderInvalidFundingFee();
+    error ParamProviderInvalidParamValue();
 
     function maintenance() external view returns (UFixed18);
     function updateMaintenance(UFixed18 newMaintenance) external;

--- a/packages/perennial/contracts/interfaces/IPayoffProvider.sol
+++ b/packages/perennial/contracts/interfaces/IPayoffProvider.sol
@@ -6,6 +6,8 @@ import "@equilibria/perennial-oracle/contracts/interfaces/IOracleProvider.sol";
 import "./types/PayoffDefinition.sol";
 
 interface IPayoffProvider {
+    event OracleUpdated(address newOracle);
+
     error PayoffProviderInvalidOracle();
     error PayoffProviderInvalidPayoffDefinitionError();
 

--- a/packages/perennial/contracts/interfaces/IPerennialLens.sol
+++ b/packages/perennial/contracts/interfaces/IPerennialLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/perennial-oracle/contracts/interfaces/IOracleProvider.sol";
 import "./IProduct.sol";

--- a/packages/perennial/contracts/interfaces/IProduct.sol
+++ b/packages/perennial/contracts/interfaces/IProduct.sol
@@ -62,8 +62,6 @@ interface IProduct is IPayoffProvider, IParamProvider {
     error ProductInLiquidationError();
     error ProductMakerOverLimitError();
     error ProductOracleBootstrappingError();
-    error ProductNotOwnerError();
-    error ProductInvalidOracle();
     error ProductClosedError();
 
     function name() external view returns (string memory);

--- a/packages/perennial/contracts/interfaces/IProduct.sol
+++ b/packages/perennial/contracts/interfaces/IProduct.sol
@@ -95,4 +95,5 @@ interface IProduct is IPayoffProvider, IParamProvider {
     function rate(Position memory position) external view returns (Fixed18);
     function closed() external view returns (bool);
     function updateClosed(bool newClosed) external;
+    function updateOracle(IOracleProvider newOracle) external;
 }

--- a/packages/perennial/contracts/interfaces/types/PayoffDefinition.sol
+++ b/packages/perennial/contracts/interfaces/types/PayoffDefinition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/utils/Address.sol";
 import "../../interfaces/IContractPayoffProvider.sol";

--- a/packages/perennial/contracts/interfaces/types/PendingFeeUpdates.sol
+++ b/packages/perennial/contracts/interfaces/types/PendingFeeUpdates.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 

--- a/packages/perennial/contracts/lens/PerennialLens.sol
+++ b/packages/perennial/contracts/lens/PerennialLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "../interfaces/IPerennialLens.sol";
 

--- a/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
+++ b/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";
@@ -101,12 +101,10 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         // Initiate
         _controller.incentivizer().sync(currentOracleVersion);
         UFixed18 boundedFundingFee = _boundedFundingFee();
-        UFixed18 accumulatedFee;
 
         // value a->b
-        accumulatedFee = accumulatedFee.add(
-            _accumulator.accumulate(boundedFundingFee, _position, latestOracleVersion, settleOracleVersion)
-        );
+        UFixed18 accumulatedFee = _accumulator.accumulate(
+            boundedFundingFee, _position, latestOracleVersion, settleOracleVersion);
 
         // position a->b
         _position.settle(_latestVersion, settleOracleVersion);
@@ -165,16 +163,12 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
             ? currentOracleVersion // if b == c, don't re-call provider for oracle version
             : atVersion(_settleVersion);
 
-        // initialize
-        Fixed18 accumulated;
-
         // sync incentivizer before accumulator
         _controller.incentivizer().syncAccount(account, settleOracleVersion);
 
         // value a->b
-        accumulated = accumulated.add(
-            _accumulators[account].syncTo(_accumulator, _positions[account], settleOracleVersion.version).sum()
-        );
+        Fixed18 accumulated = _accumulators[account].syncTo(
+            _accumulator, _positions[account], settleOracleVersion.version).sum();
 
         // position a->b
         _positions[account].settle(settleOracleVersion);

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -503,6 +503,15 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         emit ClosedUpdated(newClosed, oracleVersion.version);
     }
 
+    /**
+     * @notice Updates underlying product oracle
+     * @dev only callable by product owner
+     * @param newOracle new oracle address
+     */
+    function updateOracle(IOracleProvider newOracle) external onlyProductOwner {
+        _updateOracle(address(newOracle));
+    }
+
     /// @dev Limit total maker for guarded rollouts
     modifier makerInvariant() {
         _;

--- a/packages/perennial/contracts/product/UParamProvider.sol
+++ b/packages/perennial/contracts/product/UParamProvider.sol
@@ -100,7 +100,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newFundingFee new funding fee value
      */
     function _updateFundingFee(UFixed18 newFundingFee) private {
-        if (newFundingFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFundingFee();
+        if (newFundingFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _fundingFee.store(newFundingFee);
         emit FundingFeeUpdated(newFundingFee, _productVersion());
     }
@@ -119,7 +119,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newMakerFee new maker fee value
      */
     function _updateMakerFee(UFixed18 newMakerFee) private {
-        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidMakerFee();
+        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _makerFee.store(newMakerFee);
         emit MakerFeeUpdated(newMakerFee, _productVersion());
     }
@@ -129,7 +129,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newMakerFee new maker fee value
      */
     function _updatePendingMakerFee(UFixed18 newMakerFee) private {
-        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidMakerFee();
+        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updateMakerFee(newMakerFee);
         _pendingFeeUpdates.store(pendingFees_);
@@ -154,7 +154,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newTakerFee new taker fee value
      */
     function _updateTakerFee(UFixed18 newTakerFee) private {
-        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidTakerFee();
+        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _takerFee.store(newTakerFee);
         emit TakerFeeUpdated(newTakerFee, _productVersion());
     }
@@ -164,7 +164,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newTakerFee new taker fee value
      */
     function _updatePendingTakerFee(UFixed18 newTakerFee) private {
-        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidTakerFee();
+        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updateTakerFee(newTakerFee);
         _pendingFeeUpdates.store(pendingFees_);
@@ -189,7 +189,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newPositionFee new position fee value
      */
     function _updatePositionFee(UFixed18 newPositionFee) private {
-        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidPositionFee();
+        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _positionFee.store(newPositionFee);
         emit PositionFeeUpdated(newPositionFee, _productVersion());
     }
@@ -199,7 +199,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newPositionFee new position fee value
      */
     function _updatePendingPositionFee(UFixed18 newPositionFee) private {
-        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidPositionFee();
+        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updatePositionFee(newPositionFee);
         _pendingFeeUpdates.store(pendingFees_);

--- a/packages/perennial/contracts/product/UPayoffProvider.sol
+++ b/packages/perennial/contracts/product/UPayoffProvider.sol
@@ -31,8 +31,7 @@ abstract contract UPayoffProvider is IPayoffProvider, UInitializable {
      */
     // solhint-disable-next-line func-name-mixedcase
     function __UPayoffProvider__initialize(IOracleProvider oracle_, PayoffDefinition calldata payoffDefinition_) internal onlyInitializer {
-        if (!Address.isContract(address(oracle_))) revert PayoffProviderInvalidOracle();
-        _oracle.store(address(oracle_));
+        _updateOracle(address(oracle_));
 
         if (!payoffDefinition_.valid()) revert PayoffProviderInvalidPayoffDefinitionError();
         _payoffDefinition.store(payoffDefinition_);
@@ -56,7 +55,17 @@ abstract contract UPayoffProvider is IPayoffProvider, UInitializable {
     }
 
     /**
-     * @notice Yook to call sync() on the oracle provider and transform the resulting oracle version
+     * @notice Updates oracle to newOracle address
+     */
+    function _updateOracle(address newOracle) internal {
+        if (!Address.isContract(newOracle)) revert PayoffProviderInvalidOracle();
+        _oracle.store(newOracle);
+
+        emit OracleUpdated(newOracle);
+    }
+
+    /**
+     * @notice Hook to call sync() on the oracle provider and transform the resulting oracle version
      */
     function _sync() internal returns (IOracleProvider.OracleVersion memory) {
         return _transform(oracle().sync());

--- a/packages/perennial/contracts/product/types/accumulator/AccountAccumulator.sol
+++ b/packages/perennial/contracts/product/types/accumulator/AccountAccumulator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/types/Accumulator.sol";
 import "../position/AccountPosition.sol";

--- a/packages/perennial/contracts/product/types/accumulator/VersionedAccumulator.sol
+++ b/packages/perennial/contracts/product/types/accumulator/VersionedAccumulator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/IProduct.sol";
 import "../../../interfaces/types/Accumulator.sol";

--- a/packages/perennial/contracts/product/types/position/AccountPosition.sol
+++ b/packages/perennial/contracts/product/types/position/AccountPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/IProduct.sol";
 import "../../../interfaces/types/PrePosition.sol";

--- a/packages/perennial/contracts/product/types/position/VersionedPosition.sol
+++ b/packages/perennial/contracts/product/types/position/VersionedPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/types/PrePosition.sol";
 import "../../../interfaces/types/PackedPosition.sol";

--- a/packages/perennial/contracts/test/TestnetBatcher.sol
+++ b/packages/perennial/contracts/test/TestnetBatcher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import "@equilibria/emptyset-batcher/interfaces/IBatcher.sol";

--- a/packages/perennial/contracts/test/TestnetDSU.sol
+++ b/packages/perennial/contracts/test/TestnetDSU.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/perennial/contracts/test/TestnetProductProvider.sol
+++ b/packages/perennial/contracts/test/TestnetProductProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/curve/types/JumpRateUtilizationCurve.sol";
 import "../interfaces/IContractPayoffProvider.sol";

--- a/packages/perennial/contracts/test/TestnetReserve.sol
+++ b/packages/perennial/contracts/test/TestnetReserve.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/perennial/contracts/test/TestnetUSDC.sol
+++ b/packages/perennial/contracts/test/TestnetUSDC.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/perennial/hardhat.config.ts
+++ b/packages/perennial/hardhat.config.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'path'
 
-import defaultConfig, { OPTIMIZER_ENABLED, SOLIDITY_VERSION } from '../common/hardhat.default.config'
+import defaultConfig, { OPTIMIZER_ENABLED } from '../common/hardhat.default.config'
 const eqPerennialOracleDir = dirname(require.resolve('@equilibria/perennial-oracle/package.json'))
 
 // This Solidity config produces small contract sizes, and is useful when
@@ -8,7 +8,7 @@ const eqPerennialOracleDir = dirname(require.resolve('@equilibria/perennial-orac
 // function call will likely use extra gas.
 // Mostly inspired by Compound Comet's setup: https://github.com/compound-finance/comet/blob/main/hardhat.config.ts#L124
 const MINIMUM_CONTRACT_SIZE_SOLIDITY_OVERRIDES = {
-  version: SOLIDITY_VERSION,
+  version: '0.8.17',
   settings: {
     viaIR: OPTIMIZER_ENABLED,
     optimizer: OPTIMIZER_ENABLED

--- a/packages/perennial/test/unit/product/Product.test.ts
+++ b/packages/perennial/test/unit/product/Product.test.ts
@@ -338,19 +338,19 @@ describe('Product', () => {
     it('reverts if fees are too high', async () => {
       await expect(product.updateFundingFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidFundingFee',
+        'ParamProviderInvalidParamValue',
       )
       await expect(product.updateMakerFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidMakerFee',
+        'ParamProviderInvalidParamValue',
       )
       await expect(product.updateTakerFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidTakerFee',
+        'ParamProviderInvalidParamValue',
       )
       await expect(product.updatePositionFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidPositionFee',
+        'ParamProviderInvalidParamValue',
       )
     })
   })

--- a/packages/perennial/test/unit/product/Product.test.ts
+++ b/packages/perennial/test/unit/product/Product.test.ts
@@ -185,6 +185,11 @@ describe('Product', () => {
         .to.emit(product, 'JumpRateUtilizationCurveUpdated')
         .withArgs(newCurve, 0)
 
+      const newOracle = await deployMockContract(owner, IOracleProvider__factory.abi)
+      await expect(product.updateOracle(newOracle.address))
+        .to.emit(product, 'OracleUpdated')
+        .withArgs(newOracle.address)
+
       expect(product.settle).to.have.callCount(7)
 
       expect(await product['maintenance()']()).to.equal(utils.parseEther('0.1'))
@@ -199,6 +204,8 @@ describe('Product', () => {
       expect(curve.maxRate).to.equal(utils.parseEther('0.20'))
       expect(curve.targetRate).to.equal(utils.parseEther('0.30'))
       expect(curve.targetUtilization).to.equal(utils.parseEther('0.4'))
+
+      expect(await product.oracle()).to.equal(newOracle.address)
     })
 
     describe('pending fee updates', () => {
@@ -322,6 +329,9 @@ describe('Product', () => {
         .withArgs(1)
       await expect(product.connect(user).updateMakerLimit(utils.parseEther('0.5')))
         .to.be.be.revertedWithCustomError(product, 'NotOwnerError')
+        .withArgs(1)
+      await expect(product.connect(user).updateOracle(user.address))
+        .to.be.revertedWithCustomError(product, 'NotOwnerError')
         .withArgs(1)
     })
 


### PR DESCRIPTION
The ChainlinkOracle logic for tracking `_startingVersionForPhaseId` was flawed in that it does not sum on top of prior values, resulting in incorrect version mapping to phases. This bug was reported by user `obront` on Immunefi.

Also updates Product to allow for updating the oracle.