### PR TITLE
Reduce Product.sol size to get deployable

### DIFF
--- a/packages/perennial/contracts/collateral/Collateral.sol
+++ b/packages/perennial/contracts/collateral/Collateral.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/collateral/types/OptimisticLedger.sol
+++ b/packages/perennial/contracts/collateral/types/OptimisticLedger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 

--- a/packages/perennial/contracts/controller/Controller.sol
+++ b/packages/perennial/contracts/controller/Controller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";

--- a/packages/perennial/contracts/controller/UControllerProvider.sol
+++ b/packages/perennial/contracts/controller/UControllerProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/storage/UStorage.sol";

--- a/packages/perennial/contracts/forwarder/Forwarder.sol
+++ b/packages/perennial/contracts/forwarder/Forwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "../interfaces/IForwarder.sol";
 

--- a/packages/perennial/contracts/incentivizer/Incentivizer.sol
+++ b/packages/perennial/contracts/incentivizer/Incentivizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/incentivizer/types/ProductManager.sol
+++ b/packages/perennial/contracts/incentivizer/types/ProductManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./Program.sol";

--- a/packages/perennial/contracts/incentivizer/types/Program.sol
+++ b/packages/perennial/contracts/incentivizer/types/Program.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../interfaces/types/ProgramInfo.sol";
 

--- a/packages/perennial/contracts/interfaces/IForwarder.sol
+++ b/packages/perennial/contracts/interfaces/IForwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/token/types/Token18.sol";
 import "@equilibria/root/token/types/Token6.sol";

--- a/packages/perennial/contracts/interfaces/IMultiInvoker.sol
+++ b/packages/perennial/contracts/interfaces/IMultiInvoker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/token/types/Token6.sol";
 import "@equilibria/root/token/types/Token18.sol";

--- a/packages/perennial/contracts/interfaces/IParamProvider.sol
+++ b/packages/perennial/contracts/interfaces/IParamProvider.sol
@@ -20,10 +20,7 @@ interface IParamProvider {
         uint256 version
     );
 
-    error ParamProviderInvalidMakerFee();
-    error ParamProviderInvalidTakerFee();
-    error ParamProviderInvalidPositionFee();
-    error ParamProviderInvalidFundingFee();
+    error ParamProviderInvalidFeeValue();
 
     function maintenance() external view returns (UFixed18);
     function updateMaintenance(UFixed18 newMaintenance) external;

--- a/packages/perennial/contracts/interfaces/IParamProvider.sol
+++ b/packages/perennial/contracts/interfaces/IParamProvider.sol
@@ -20,7 +20,7 @@ interface IParamProvider {
         uint256 version
     );
 
-    error ParamProviderInvalidFeeValue();
+    error ParamProviderInvalidParamValue();
 
     function maintenance() external view returns (UFixed18);
     function updateMaintenance(UFixed18 newMaintenance) external;

--- a/packages/perennial/contracts/interfaces/IPerennialLens.sol
+++ b/packages/perennial/contracts/interfaces/IPerennialLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/perennial-oracle/contracts/interfaces/IOracleProvider.sol";
 import "./IProduct.sol";

--- a/packages/perennial/contracts/interfaces/IProduct.sol
+++ b/packages/perennial/contracts/interfaces/IProduct.sol
@@ -62,8 +62,6 @@ interface IProduct is IPayoffProvider, IParamProvider {
     error ProductInLiquidationError();
     error ProductMakerOverLimitError();
     error ProductOracleBootstrappingError();
-    error ProductNotOwnerError();
-    error ProductInvalidOracle();
     error ProductClosedError();
 
     function name() external view returns (string memory);

--- a/packages/perennial/contracts/interfaces/types/PayoffDefinition.sol
+++ b/packages/perennial/contracts/interfaces/types/PayoffDefinition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/utils/Address.sol";
 import "../../interfaces/IContractPayoffProvider.sol";

--- a/packages/perennial/contracts/interfaces/types/PendingFeeUpdates.sol
+++ b/packages/perennial/contracts/interfaces/types/PendingFeeUpdates.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 

--- a/packages/perennial/contracts/lens/PerennialLens.sol
+++ b/packages/perennial/contracts/lens/PerennialLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "../interfaces/IPerennialLens.sol";
 

--- a/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
+++ b/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -101,12 +101,10 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         // Initiate
         _controller.incentivizer().sync(currentOracleVersion);
         UFixed18 boundedFundingFee = _boundedFundingFee();
-        UFixed18 accumulatedFee;
 
         // value a->b
-        accumulatedFee = accumulatedFee.add(
-            _accumulator.accumulate(boundedFundingFee, _position, latestOracleVersion, settleOracleVersion)
-        );
+        UFixed18 accumulatedFee = _accumulator.accumulate(
+            boundedFundingFee, _position, latestOracleVersion, settleOracleVersion);
 
         // position a->b
         _position.settle(_latestVersion, settleOracleVersion);
@@ -165,16 +163,12 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
             ? currentOracleVersion // if b == c, don't re-call provider for oracle version
             : atVersion(_settleVersion);
 
-        // initialize
-        Fixed18 accumulated;
-
         // sync incentivizer before accumulator
         _controller.incentivizer().syncAccount(account, settleOracleVersion);
 
         // value a->b
-        accumulated = accumulated.add(
-            _accumulators[account].syncTo(_accumulator, _positions[account], settleOracleVersion.version).sum()
-        );
+        Fixed18 accumulated = _accumulators[account].syncTo(
+            _accumulator, _positions[account], settleOracleVersion.version).sum();
 
         // position a->b
         _positions[account].settle(settleOracleVersion);

--- a/packages/perennial/contracts/product/UParamProvider.sol
+++ b/packages/perennial/contracts/product/UParamProvider.sol
@@ -100,7 +100,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newFundingFee new funding fee value
      */
     function _updateFundingFee(UFixed18 newFundingFee) private {
-        if (newFundingFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newFundingFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _fundingFee.store(newFundingFee);
         emit FundingFeeUpdated(newFundingFee, _productVersion());
     }
@@ -119,7 +119,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newMakerFee new maker fee value
      */
     function _updateMakerFee(UFixed18 newMakerFee) private {
-        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _makerFee.store(newMakerFee);
         emit MakerFeeUpdated(newMakerFee, _productVersion());
     }
@@ -129,7 +129,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newMakerFee new maker fee value
      */
     function _updatePendingMakerFee(UFixed18 newMakerFee) private {
-        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updateMakerFee(newMakerFee);
         _pendingFeeUpdates.store(pendingFees_);
@@ -154,7 +154,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newTakerFee new taker fee value
      */
     function _updateTakerFee(UFixed18 newTakerFee) private {
-        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _takerFee.store(newTakerFee);
         emit TakerFeeUpdated(newTakerFee, _productVersion());
     }
@@ -164,7 +164,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newTakerFee new taker fee value
      */
     function _updatePendingTakerFee(UFixed18 newTakerFee) private {
-        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updateTakerFee(newTakerFee);
         _pendingFeeUpdates.store(pendingFees_);
@@ -189,7 +189,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newPositionFee new position fee value
      */
     function _updatePositionFee(UFixed18 newPositionFee) private {
-        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         _positionFee.store(newPositionFee);
         emit PositionFeeUpdated(newPositionFee, _productVersion());
     }
@@ -199,7 +199,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newPositionFee new position fee value
      */
     function _updatePendingPositionFee(UFixed18 newPositionFee) private {
-        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
+        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidParamValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updatePositionFee(newPositionFee);
         _pendingFeeUpdates.store(pendingFees_);

--- a/packages/perennial/contracts/product/UParamProvider.sol
+++ b/packages/perennial/contracts/product/UParamProvider.sol
@@ -100,7 +100,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newFundingFee new funding fee value
      */
     function _updateFundingFee(UFixed18 newFundingFee) private {
-        if (newFundingFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFundingFee();
+        if (newFundingFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         _fundingFee.store(newFundingFee);
         emit FundingFeeUpdated(newFundingFee, _productVersion());
     }
@@ -119,7 +119,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newMakerFee new maker fee value
      */
     function _updateMakerFee(UFixed18 newMakerFee) private {
-        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidMakerFee();
+        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         _makerFee.store(newMakerFee);
         emit MakerFeeUpdated(newMakerFee, _productVersion());
     }
@@ -129,7 +129,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newMakerFee new maker fee value
      */
     function _updatePendingMakerFee(UFixed18 newMakerFee) private {
-        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidMakerFee();
+        if (newMakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updateMakerFee(newMakerFee);
         _pendingFeeUpdates.store(pendingFees_);
@@ -154,7 +154,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newTakerFee new taker fee value
      */
     function _updateTakerFee(UFixed18 newTakerFee) private {
-        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidTakerFee();
+        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         _takerFee.store(newTakerFee);
         emit TakerFeeUpdated(newTakerFee, _productVersion());
     }
@@ -164,7 +164,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newTakerFee new taker fee value
      */
     function _updatePendingTakerFee(UFixed18 newTakerFee) private {
-        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidTakerFee();
+        if (newTakerFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updateTakerFee(newTakerFee);
         _pendingFeeUpdates.store(pendingFees_);
@@ -189,7 +189,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newPositionFee new position fee value
      */
     function _updatePositionFee(UFixed18 newPositionFee) private {
-        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidPositionFee();
+        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         _positionFee.store(newPositionFee);
         emit PositionFeeUpdated(newPositionFee, _productVersion());
     }
@@ -199,7 +199,7 @@ abstract contract UParamProvider is IParamProvider, UControllerProvider {
      * @param newPositionFee new position fee value
      */
     function _updatePendingPositionFee(UFixed18 newPositionFee) private {
-        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidPositionFee();
+        if (newPositionFee.gt(UFixed18Lib.ONE)) revert ParamProviderInvalidFeeValue();
         PendingFeeUpdates memory pendingFees_ = pendingFeeUpdates();
         pendingFees_.updatePositionFee(newPositionFee);
         _pendingFeeUpdates.store(pendingFees_);

--- a/packages/perennial/contracts/product/types/accumulator/AccountAccumulator.sol
+++ b/packages/perennial/contracts/product/types/accumulator/AccountAccumulator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/types/Accumulator.sol";
 import "../position/AccountPosition.sol";

--- a/packages/perennial/contracts/product/types/accumulator/VersionedAccumulator.sol
+++ b/packages/perennial/contracts/product/types/accumulator/VersionedAccumulator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/IProduct.sol";
 import "../../../interfaces/types/Accumulator.sol";

--- a/packages/perennial/contracts/product/types/position/AccountPosition.sol
+++ b/packages/perennial/contracts/product/types/position/AccountPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/IProduct.sol";
 import "../../../interfaces/types/PrePosition.sol";

--- a/packages/perennial/contracts/product/types/position/VersionedPosition.sol
+++ b/packages/perennial/contracts/product/types/position/VersionedPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.13;
 
 import "../../../interfaces/types/PrePosition.sol";
 import "../../../interfaces/types/PackedPosition.sol";

--- a/packages/perennial/contracts/test/TestnetBatcher.sol
+++ b/packages/perennial/contracts/test/TestnetBatcher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import "@equilibria/emptyset-batcher/interfaces/IBatcher.sol";

--- a/packages/perennial/contracts/test/TestnetDSU.sol
+++ b/packages/perennial/contracts/test/TestnetDSU.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/perennial/contracts/test/TestnetProductProvider.sol
+++ b/packages/perennial/contracts/test/TestnetProductProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/root/curve/types/JumpRateUtilizationCurve.sol";
 import "../interfaces/IContractPayoffProvider.sol";

--- a/packages/perennial/contracts/test/TestnetReserve.sol
+++ b/packages/perennial/contracts/test/TestnetReserve.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/perennial/contracts/test/TestnetUSDC.sol
+++ b/packages/perennial/contracts/test/TestnetUSDC.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/perennial/hardhat.config.ts
+++ b/packages/perennial/hardhat.config.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'path'
 
-import defaultConfig, { OPTIMIZER_ENABLED, SOLIDITY_VERSION } from '../common/hardhat.default.config'
+import defaultConfig, { OPTIMIZER_ENABLED } from '../common/hardhat.default.config'
 const eqPerennialOracleDir = dirname(require.resolve('@equilibria/perennial-oracle/package.json'))
 
 // This Solidity config produces small contract sizes, and is useful when
@@ -8,7 +8,7 @@ const eqPerennialOracleDir = dirname(require.resolve('@equilibria/perennial-orac
 // function call will likely use extra gas.
 // Mostly inspired by Compound Comet's setup: https://github.com/compound-finance/comet/blob/main/hardhat.config.ts#L124
 const MINIMUM_CONTRACT_SIZE_SOLIDITY_OVERRIDES = {
-  version: SOLIDITY_VERSION,
+  version: '0.8.17',
   settings: {
     viaIR: OPTIMIZER_ENABLED,
     optimizer: OPTIMIZER_ENABLED

--- a/packages/perennial/test/unit/product/Product.test.ts
+++ b/packages/perennial/test/unit/product/Product.test.ts
@@ -338,19 +338,19 @@ describe('Product', () => {
     it('reverts if fees are too high', async () => {
       await expect(product.updateFundingFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidFeeValue',
+        'ParamProviderInvalidParamValue',
       )
       await expect(product.updateMakerFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidFeeValue',
+        'ParamProviderInvalidParamValue',
       )
       await expect(product.updateTakerFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidFeeValue',
+        'ParamProviderInvalidParamValue',
       )
       await expect(product.updatePositionFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidFeeValue',
+        'ParamProviderInvalidParamValue',
       )
     })
   })

--- a/packages/perennial/test/unit/product/Product.test.ts
+++ b/packages/perennial/test/unit/product/Product.test.ts
@@ -338,19 +338,19 @@ describe('Product', () => {
     it('reverts if fees are too high', async () => {
       await expect(product.updateFundingFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidFundingFee',
+        'ParamProviderInvalidFeeValue',
       )
       await expect(product.updateMakerFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidMakerFee',
+        'ParamProviderInvalidFeeValue',
       )
       await expect(product.updateTakerFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidTakerFee',
+        'ParamProviderInvalidFeeValue',
       )
       await expect(product.updatePositionFee(utils.parseEther('1.01'))).to.be.be.revertedWithCustomError(
         product,
-        'ParamProviderInvalidPositionFee',
+        'ParamProviderInvalidFeeValue',
       )
     })
   })


### PR DESCRIPTION
Introduces 4 changes:

* Consolidate `Invalid*Fee` errors into a single `InvalidFeeValue in `IParamProvider`
* Inlines `UFixed18 accumulatedFee` in Settle and SettleAccount
* Moves all type contracts in `perennial` to `^0.8.13` if they weren't already
* Moves all other contracts in `perennial` to `^0.8.15`

The last two allow us to compile Product with `0.8.17` for extra savings. After this, the `Product.sol` contract comes out to `24.532 KB`