### PR TITLE
ChainlinkFeedOracle

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.4",
     "@nomiclabs/hardhat-ethers": "^2.2.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
+    "@chainlink/contracts": "0.5.1",
     "@openzeppelin/contracts": "4.6.0",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.0",

--- a/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
@@ -29,7 +29,7 @@ contract ChainlinkFeedOracle is IOracleProvider {
 
     /**
      * @notice Initializes the contract state
-     * @param aggregator_ Chainlink price feed registry
+     * @param aggregator_ Chainlink price feed aggregator
      */
     constructor(ChainlinkAggregator aggregator_) {
         aggregator = aggregator_;

--- a/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
@@ -48,6 +48,10 @@ contract ChainlinkFeedOracle is IOracleProvider {
         _decimalOffset = SafeCast.toInt256(10 ** aggregator.decimals());
 
         _firstPhaseId = aggregator_.phase();
+        // Load the phases array with previous phase values
+        while (_firstPhaseId > _latestPhaseId()) {
+            _phases.push(Phase(_phases[_phases.length - 1].startingVersion, uint128(0)));
+        }
     }
 
     /**
@@ -62,7 +66,7 @@ contract ChainlinkFeedOracle is IOracleProvider {
         while (round.phaseId() > _latestPhaseId()) {
             _phases.push(
                 Phase(
-                    uint128(aggregator.getRoundCount(_latestPhaseId())) +
+                    uint128(aggregator.getRoundCount(_latestPhaseId(), round.timestamp)) +
                         _phases[_phases.length - 1].startingVersion,
                     uint128(_aggregatorRoundIdToProxyRoundId(_latestPhaseId() + 1, 1))
                 )

--- a/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.15;
+
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "./interfaces/IOracleProvider.sol";
+import "./types/ChainlinkAggregator.sol";
+
+/**
+ * @title ChainlinkOracle
+ * @notice Chainlink implementation of the IOracle interface.
+ * @dev One instance per Chainlink price feed should be deployed. Multiple products may use the same
+ *      ChainlinkOracle instance if their payoff functions are based on the same underlying oracle.
+ *      This implementation only support non-negative prices.
+ */
+contract ChainlinkFeedOracle is IOracleProvider {
+    error InvalidVersionRequested(uint256 version);
+
+    /// @dev Chainlink feed aggregator address
+    ChainlinkAggregator public immutable aggregator;
+
+    /// @dev Decimal offset used to normalize chainlink price to 18 decimals
+    int256 private immutable _decimalOffset;
+
+    /// @dev First valid phase for this Oracle
+    uint256 private _firstPhaseId;
+
+    /// @dev Mapping of the starting data for each underlying phase
+    Phase[] private _phases;
+
+    struct Phase {
+        uint128 startingVersion;
+        uint128 startingRoundId;
+    }
+
+    /**
+     * @notice Initializes the contract state
+     * @param aggregator_ Chainlink price feed registry
+     */
+    constructor(ChainlinkAggregator aggregator_) {
+        aggregator = aggregator_;
+
+        // phaseId is 1-indexed, skip index 0
+        _phases.push(Phase(uint128(0), uint128(0)));
+        // phaseId is 1-indexed, first phase starts as version 0
+        _phases.push(Phase(uint128(0), uint128(_aggregatorRoundIdToProxyRoundId(1, 1))));
+
+        _decimalOffset = SafeCast.toInt256(10 ** aggregator.decimals());
+
+        _firstPhaseId = aggregator_.phase();
+    }
+
+    /**
+     * @notice Checks for a new price and updates the internal phase annotation state accordingly
+     * @return The current oracle version after sync
+     */
+    function sync() external returns (OracleVersion memory) {
+        // Fetch latest round
+        ChainlinkRound memory round = aggregator.getLatestRound();
+
+        // Update phase annotation when new phase detected
+        while (round.phaseId() > _latestPhaseId()) {
+            _phases.push(
+                Phase(
+                    uint128(aggregator.getRoundCount(_latestPhaseId())) +
+                        _phases[_phases.length - 1].startingVersion,
+                    uint128(_aggregatorRoundIdToProxyRoundId(_latestPhaseId() + 1, 1))
+                )
+            );
+        }
+
+        // Return packaged oracle version
+        return _buildOracleVersion(round);
+    }
+
+    /**
+     * @notice Returns the current oracle version
+     * @return oracleVersion Current oracle version
+     */
+    function currentVersion() public view returns (OracleVersion memory oracleVersion) {
+        return _buildOracleVersion(aggregator.getLatestRound());
+    }
+
+    /**
+     * @notice Returns the current oracle version
+     * @param version The version of which to lookup
+     * @return oracleVersion Oracle version at version `version`
+     */
+    function atVersion(uint256 version) public view returns (OracleVersion memory oracleVersion) {
+        return _buildOracleVersion(aggregator.getRound(_versionToRoundId(version)), version);
+    }
+
+    /**
+     * @notice Builds an oracle version object from a Chainlink round object
+     * @dev Computes the version for the round
+     * @param round Chainlink round to build from
+     * @return Built oracle version
+     */
+    function _buildOracleVersion(ChainlinkRound memory round) private view returns (OracleVersion memory) {
+        Phase memory phase = _phases[round.phaseId()];
+        uint256 version = uint256(phase.startingVersion) + round.roundId - uint256(phase.startingRoundId);
+        return _buildOracleVersion(round, version);
+    }
+
+    /**
+     * @notice Builds an oracle version object from a Chainlink round object
+     * @param round Chainlink round to build from
+     * @param version Determined version for the round
+     * @return Built oracle version
+     */
+    function _buildOracleVersion(ChainlinkRound memory round, uint256 version)
+    private view returns (OracleVersion memory) {
+        Fixed18 price = Fixed18Lib.ratio(round.answer, _decimalOffset);
+        return OracleVersion({ version: version, timestamp: round.timestamp, price: price });
+    }
+
+    /**
+     * @notice Computes the chainlink round ID from a version
+     * @param version Version to compute from
+     * @return Chainlink round ID
+     */
+    function _versionToRoundId(uint256 version) private view returns (uint256) {
+        Phase memory phase = _versionToPhase(version);
+        return uint256(phase.startingRoundId) + version - uint256(phase.startingVersion);
+    }
+
+    /**
+     * @notice Computes the chainlink phase ID from a version
+     * @param version Version to compute from
+     * @return phase Chainlink phase
+     */
+    function _versionToPhase(uint256 version) private view returns (Phase memory phase) {
+        uint256 phaseId = _latestPhaseId();
+        phase = _phases[phaseId];
+        while (uint256(phase.startingVersion) > version) {
+            phaseId--;
+            phase = _phases[phaseId];
+            if (phaseId < _firstPhaseId) revert InvalidVersionRequested(version);
+        }
+    }
+
+    /**
+     * @notice Returns the latest phase ID that this contract has seen via `sync()`
+     * @return Latest seen phase ID
+     */
+    function _latestPhaseId() private view returns (uint16) {
+        return uint16(_phases.length - 1);
+    }
+
+    function _aggregatorRoundIdToProxyRoundId(uint16 phaseId, uint80 aggregatorRoundId) private pure returns (uint256) {
+        return (uint256(phaseId) << 64) + aggregatorRoundId;
+    }
+}

--- a/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
@@ -11,12 +11,12 @@ using ChainlinkAggregatorLib for ChainlinkAggregator global;
 
 /**
  * @title ChainlinkAggregatorLib
- * @notice Library that manages interfacing with the Chainlink Feed Registry.
+ * @notice Library that manages interfacing with the Chainlink Feed Aggregator Proxy.
  */
 library ChainlinkAggregatorLib {
     /**
      * @notice Returns the decimal amount for a specific feed
-     * @param self Chainlink Feed Registry to operate on
+     * @param self Chainlink Feed Aggregator to operate on
      * @return Decimal amount
      */
     function decimals(ChainlinkAggregator self) internal view returns (uint8) {
@@ -25,7 +25,7 @@ library ChainlinkAggregatorLib {
 
     /**
      * @notice Returns the latest round data for a specific feed
-     * @param self Chainlink Feed Registry to operate on
+     * @param self Chainlink Feed Aggregator to operate on
      * @return Latest round data
      */
     function getLatestRound(ChainlinkAggregator self) internal view returns (ChainlinkRound memory) {
@@ -36,7 +36,7 @@ library ChainlinkAggregatorLib {
 
     /**
      * @notice Returns a specific round's data for a specific feed
-     * @param self Chainlink Feed Registry to operate on
+     * @param self Chainlink Feed Aggregator to operate on
      * @param roundId The specific round to fetch data for
      * @return Specific round's data
      */
@@ -49,8 +49,10 @@ library ChainlinkAggregatorLib {
 
     /**
      * @notice Returns the first round ID for a specific phase ID
-     * @param self Chainlink Feed Registry to operate on
+     * @param self Chainlink Feed Aggregator to operate on
      * @param phaseId The specific phase to fetch data for
+     * @param startingRoundId starting roundId for the aggregator proxy
+     * @param maxTimestamp maximum timestamp allowed for the last round of the phase
      * @dev Assumes the phase ends at the aggregators latestRound or earlier
      * @return The number of rounds in the phase
      */
@@ -76,6 +78,8 @@ library ChainlinkAggregatorLib {
     /**
      * @notice Convert an aggregator round ID into a proxy round ID for the given phase
      * @dev Follows the logic specified in https://docs.chain.link/data-feeds/price-feeds/historical-data#roundid-in-proxy
+     * @param phaseId phase ID for the given aggregator round
+     * @param aggregatorRoundId round id for the aggregator round
      * @return Proxy roundId
      */
     function _aggregatorRoundIdToProxyRoundId(uint16 phaseId, uint80 aggregatorRoundId) private pure returns (uint256) {

--- a/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorProxyInterface.sol";
+import "./ChainlinkRound.sol";
+
+/// @dev ChainlinkAggregator type
+type ChainlinkAggregator is address;
+using ChainlinkAggregatorLib for ChainlinkAggregator global;
+
+/**
+ * @title ChainlinkAggregatorLib
+ * @notice Library that manages interfacing with the Chainlink Feed Registry.
+ */
+library ChainlinkAggregatorLib {
+    /**
+     * @notice Returns the decimal amount for a specific feed
+     * @param self Chainlink Feed Registry to operate on
+     * @return Decimal amount
+     */
+    function decimals(ChainlinkAggregator self) internal view returns (uint8) {
+        return AggregatorProxyInterface(ChainlinkAggregator.unwrap(self)).decimals();
+    }
+
+    function phase(ChainlinkAggregator self) internal view returns (uint16) {
+        return AggregatorProxyInterface(ChainlinkAggregator.unwrap(self)).phaseId();
+    }
+
+    /**
+     * @notice Returns the latest round data for a specific feed
+     * @param self Chainlink Feed Registry to operate on
+     * @return Latest round data
+     */
+    function getLatestRound(ChainlinkAggregator self) internal view returns (ChainlinkRound memory) {
+        (uint80 roundId, int256 answer, , uint256 updatedAt, ) =
+            AggregatorProxyInterface(ChainlinkAggregator.unwrap(self)).latestRoundData();
+        return ChainlinkRound({roundId: roundId, timestamp: updatedAt, answer: answer});
+    }
+
+    /**
+     * @notice Returns a specific round's data for a specific feed
+     * @param self Chainlink Feed Registry to operate on
+     * @param roundId The specific round to fetch data for
+     * @return Specific round's data
+     */
+    function getRound(ChainlinkAggregator self, uint256 roundId) internal view returns (ChainlinkRound memory) {
+        (, int256 answer, , uint256 updatedAt, ) =
+            AggregatorProxyInterface(ChainlinkAggregator.unwrap(self)).getRoundData(uint80(roundId));
+        return ChainlinkRound({roundId: roundId, timestamp: updatedAt, answer: answer});
+    }
+
+
+    /**
+     * @notice Returns the first round ID for a specific phase ID
+     * @param self Chainlink Feed Registry to operate on
+     * @param phaseId The specific phase to fetch data for
+     * @return roundCount The number of rounds in the phase
+     */
+    function getRoundCount(ChainlinkAggregator self, uint16 phaseId)
+    internal view returns (uint256) {
+        AggregatorProxyInterface proxy = AggregatorProxyInterface(ChainlinkAggregator.unwrap(self));
+        AggregatorV2V3Interface agg = AggregatorV2V3Interface(proxy.phaseAggregators(phaseId));
+
+        (uint80 aggRoundId,,,,) = agg.latestRoundData();
+        return aggRoundId + 1;
+    }
+}

--- a/packages/perennial-oracle/package.json
+++ b/packages/perennial-oracle/package.json
@@ -34,6 +34,7 @@
   "author": "",
   "license": "APACHE-2.0",
   "dependencies": {
+    "@chainlink/contracts": "0.5.1",
     "@equilibria/root": "0.1.6",
     "@openzeppelin/contracts": "4.6.0",
     "@ethersproject/bignumber": "^5.5.1"

--- a/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
@@ -241,12 +241,12 @@ describe('ChainlinkFeedOracle', () => {
           .whenCalledWith(roundId)
           .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
 
-        // const returnValue = await oracle.callStatic.sync({ gasLimit: 3e6 })
+        const returnValue = await oracle.callStatic.sync({ gasLimit: 3e6 })
         await oracle.connect(user).sync()
 
-        /* expect(returnValue.price).to.equal(utils.parseEther('1333'))
+        expect(returnValue.price).to.equal(utils.parseEther('1333'))
         expect(returnValue.timestamp).to.equal(TIMESTAMP_START + HOUR)
-        expect(returnValue.version).to.equal(80) */
+        expect(returnValue.version).to.equal(80)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(utils.parseEther('1333'))

--- a/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
@@ -1,0 +1,291 @@
+import { MockContract } from '@ethereum-waffle/mock-contract'
+import { smock, FakeContract } from '@defi-wonderland/smock'
+import { utils } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import {
+  ChainlinkFeedOracle,
+  ChainlinkFeedOracle__factory,
+  AggregatorProxyInterface,
+  AggregatorProxyInterface__factory,
+  AggregatorV2V3Interface,
+  AggregatorV2V3Interface__factory,
+} from '../../../types/generated'
+import { currentBlockTimestamp } from '../../../../common/testutil/time'
+import { buildChainlinkRoundId } from '../../../util'
+
+const { ethers } = HRE
+
+const HOUR = 60 * 60
+
+describe('ChainlinkFeedOracle', () => {
+  let owner: SignerWithAddress
+  let user: SignerWithAddress
+
+  let aggregatorProxy: FakeContract<AggregatorProxyInterface>
+  let phase1Aggregator: FakeContract<AggregatorV2V3Interface>
+  let phase2Aggregator: FakeContract<AggregatorV2V3Interface>
+
+  let oracle: ChainlinkFeedOracle
+
+  beforeEach(async () => {
+    ;[owner, user] = await ethers.getSigners()
+    aggregatorProxy = await smock.fake<AggregatorProxyInterface>(AggregatorProxyInterface__factory.abi)
+    aggregatorProxy.phaseId.returns(1)
+
+    phase1Aggregator = await smock.fake<AggregatorV2V3Interface>(AggregatorV2V3Interface__factory.abi)
+    phase2Aggregator = await smock.fake<AggregatorV2V3Interface>(AggregatorV2V3Interface__factory.abi)
+
+    aggregatorProxy.phaseAggregators.whenCalledWith(1).returns(phase1Aggregator.address)
+    aggregatorProxy.phaseAggregators.whenCalledWith(2).returns(phase2Aggregator.address)
+  })
+
+  describe('#constructor', async () => {
+    it('sets initial params', async () => {
+      aggregatorProxy.decimals.whenCalledWith().returns(8)
+
+      oracle = await new ChainlinkFeedOracle__factory(owner).deploy(aggregatorProxy.address)
+
+      expect(await oracle.aggregator()).to.equal(aggregatorProxy.address)
+    })
+  })
+
+  describe('#sync', async () => {
+    let TIMESTAMP_START: number
+
+    beforeEach(async () => {
+      TIMESTAMP_START = await currentBlockTimestamp()
+
+      aggregatorProxy.decimals.whenCalledWith().returns(8)
+      oracle = await new ChainlinkFeedOracle__factory(owner).deploy(aggregatorProxy.address)
+    })
+
+    it('syncs first version', async () => {
+      const roundId = buildChainlinkRoundId(1, 24)
+      aggregatorProxy.latestRoundData
+        .whenCalledWith()
+        .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+      aggregatorProxy.getRoundData
+        .whenCalledWith(roundId)
+        .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+      const returnValue = await oracle.callStatic.sync()
+      oracle.connect(user).sync()
+
+      expect(returnValue.price).to.equal(utils.parseEther('1111'))
+      expect(returnValue.timestamp).to.equal(TIMESTAMP_START)
+      expect(returnValue.version).to.equal(23)
+
+      const currentVersion = await oracle.currentVersion()
+      expect(currentVersion.price).to.equal(utils.parseEther('1111'))
+      expect(currentVersion.timestamp).to.equal(TIMESTAMP_START)
+      expect(currentVersion.version).to.equal(23)
+
+      const atVersion = await oracle.atVersion(23)
+      expect(atVersion.price).to.equal(utils.parseEther('1111'))
+      expect(atVersion.timestamp).to.equal(TIMESTAMP_START)
+      expect(atVersion.version).to.equal(23)
+    })
+
+    describe('after synced', async () => {
+      beforeEach(async () => {
+        const roundId = buildChainlinkRoundId(1, 24)
+
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
+          .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+        await oracle.connect(user).sync()
+      })
+
+      it('doesnt sync new version if not available', async () => {
+        const roundId = buildChainlinkRoundId(1, 24)
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
+          .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+        aggregatorProxy.getRoundData
+          .whenCalledWith(roundId)
+          .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+        const returnValue = await oracle.callStatic.sync()
+        oracle.connect(user).sync()
+
+        expect(returnValue.price).to.equal(utils.parseEther('1111'))
+        expect(returnValue.timestamp).to.equal(TIMESTAMP_START)
+        expect(returnValue.version).to.equal(23)
+
+        const currentVersion = await oracle.currentVersion()
+        expect(currentVersion.price).to.equal(utils.parseEther('1111'))
+        expect(currentVersion.timestamp).to.equal(TIMESTAMP_START)
+        expect(currentVersion.version).to.equal(23)
+
+        const atVersion = await oracle.atVersion(23)
+        expect(atVersion.price).to.equal(utils.parseEther('1111'))
+        expect(atVersion.timestamp).to.equal(TIMESTAMP_START)
+        expect(atVersion.version).to.equal(23)
+      })
+
+      it('syncs new version if available', async () => {
+        const roundId = buildChainlinkRoundId(1, 25)
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
+          .returns([roundId, ethers.BigNumber.from(122200000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        aggregatorProxy.getRoundData
+          .whenCalledWith(roundId)
+          .returns([roundId, ethers.BigNumber.from(122200000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        const returnValue = await oracle.callStatic.sync()
+        oracle.connect(user).sync()
+
+        expect(returnValue.price).to.equal(utils.parseEther('1222'))
+        expect(returnValue.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(returnValue.version).to.equal(24)
+
+        const currentVersion = await oracle.currentVersion()
+        expect(currentVersion.price).to.equal(utils.parseEther('1222'))
+        expect(currentVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(currentVersion.version).to.equal(24)
+
+        const atVersion = await oracle.atVersion(24)
+        expect(atVersion.price).to.equal(utils.parseEther('1222'))
+        expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(atVersion.version).to.equal(24)
+      })
+
+      it('syncs with new phase', async () => {
+        phase1Aggregator.latestRoundData.returns([81, 0, 0, 0, 0])
+
+        const roundId = buildChainlinkRoundId(2, 345)
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
+          .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        aggregatorProxy.getRoundData
+          .whenCalledWith(roundId)
+          .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        const returnValue = await oracle.callStatic.sync()
+        await oracle.connect(user).sync()
+
+        expect(returnValue.price).to.equal(utils.parseEther('1333'))
+        expect(returnValue.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(returnValue.version).to.equal(426)
+
+        const currentVersion = await oracle.currentVersion()
+        expect(currentVersion.price).to.equal(utils.parseEther('1333'))
+        expect(currentVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(currentVersion.version).to.equal(426)
+
+        const atVersion = await oracle.atVersion(426)
+        expect(atVersion.price).to.equal(utils.parseEther('1333'))
+        expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(atVersion.version).to.equal(426)
+      })
+    })
+  })
+
+  describe.only('#atVersion', async () => {
+    let TIMESTAMP_START: number
+
+    beforeEach(async () => {
+      TIMESTAMP_START = await currentBlockTimestamp()
+
+      aggregatorProxy.decimals.whenCalledWith().returns(8)
+      phase1Aggregator.latestRoundData.returns([400, 0, 0, 0, 0])
+      oracle = await new ChainlinkFeedOracle__factory(owner).deploy(aggregatorProxy.address)
+
+      const roundId = buildChainlinkRoundId(1, 123)
+
+      aggregatorProxy.latestRoundData
+        .whenCalledWith()
+        .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+      await oracle.connect(user).sync()
+    })
+
+    it('reads prior version', async () => {
+      const roundId = buildChainlinkRoundId(1, 13)
+
+      aggregatorProxy.getRoundData
+        .whenCalledWith(roundId)
+        .returns([roundId, ethers.BigNumber.from(111100000000), TIMESTAMP_START - HOUR, TIMESTAMP_START, roundId])
+
+      const atVersion = await oracle.atVersion(12)
+      expect(atVersion.price).to.equal(utils.parseEther('1111'))
+      expect(atVersion.timestamp).to.equal(TIMESTAMP_START)
+      expect(atVersion.version).to.equal(12)
+    })
+
+    it('reads versions in multiple phases', async () => {
+      const currentRoundId = buildChainlinkRoundId(3, 350)
+
+      phase2Aggregator.latestRoundData.returns([299, 0, 0, 0, 0])
+
+      aggregatorProxy.latestRoundData
+        .whenCalledWith()
+        .returns([
+          currentRoundId,
+          ethers.BigNumber.from(111100000000),
+          TIMESTAMP_START - HOUR,
+          TIMESTAMP_START,
+          currentRoundId,
+        ])
+
+      // Syncs from Phase 1 to Phase 3
+      await oracle.connect(user).sync()
+
+      // Check Version from Phase 1: Versions 0 to 400
+      const roundIdPhase1 = buildChainlinkRoundId(1, 13)
+      aggregatorProxy.getRoundData
+        .whenCalledWith(roundIdPhase1)
+        .returns([
+          roundIdPhase1,
+          ethers.BigNumber.from(111100000000),
+          TIMESTAMP_START - 6 * HOUR,
+          TIMESTAMP_START - 5 * HOUR,
+          roundIdPhase1,
+        ])
+      const atVersionPhase1 = await oracle.atVersion(12)
+      expect(atVersionPhase1.price).to.equal(utils.parseEther('1111'))
+      expect(atVersionPhase1.timestamp).to.equal(TIMESTAMP_START - 5 * HOUR)
+      expect(atVersionPhase1.version).to.equal(12)
+
+      // Check Version from Phase 2: Versions 401 to 700
+      const roundIdPhase2 = buildChainlinkRoundId(2, 201)
+      aggregatorProxy.getRoundData
+        .whenCalledWith(roundIdPhase2)
+        .returns([
+          roundIdPhase2,
+          ethers.BigNumber.from(123400000000),
+          TIMESTAMP_START - 3 * HOUR,
+          TIMESTAMP_START - 2 * HOUR,
+          roundIdPhase2,
+        ])
+      const atVersion2 = await oracle.atVersion(601)
+      expect(atVersion2.price).to.equal(utils.parseEther('1234'))
+      expect(atVersion2.timestamp).to.equal(TIMESTAMP_START - 2 * HOUR)
+      expect(atVersion2.version).to.equal(601)
+
+      // Check Version from Phase 3: Versions 701 onwards
+      const roundIdPhase3 = buildChainlinkRoundId(3, 1)
+      aggregatorProxy.getRoundData
+        .whenCalledWith(roundIdPhase3)
+        .returns([
+          roundIdPhase3,
+          ethers.BigNumber.from(211100000000),
+          TIMESTAMP_START - 2 * HOUR,
+          TIMESTAMP_START - 1 * HOUR,
+          roundIdPhase3,
+        ])
+      const atVersion3 = await oracle.atVersion(701)
+      expect(atVersion3.price).to.equal(utils.parseEther('2111'))
+      expect(atVersion3.timestamp).to.equal(TIMESTAMP_START - 1 * HOUR)
+      expect(atVersion3.version).to.equal(701)
+    })
+  })
+})

--- a/packages/perennial/package.json
+++ b/packages/perennial/package.json
@@ -31,7 +31,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@chainlink/contracts": "0.3.1",
+    "@chainlink/contracts": "0.5.1",
     "@equilibria/emptyset-batcher": "0.1.0",
     "@equilibria/perennial-oracle": "0.1.0",
     "@equilibria/root": "0.1.6",

--- a/patches/@chainlink+contracts+0.5.1.patch
+++ b/patches/@chainlink+contracts+0.5.1.patch
@@ -1,0 +1,42 @@
+diff --git a/node_modules/@chainlink/contracts/src/v0.8/interfaces/AggregatorProxyInterface.sol b/node_modules/@chainlink/contracts/src/v0.8/interfaces/AggregatorProxyInterface.sol
+new file mode 100644
+index 0000000..54f65be
+--- /dev/null
++++ b/node_modules/@chainlink/contracts/src/v0.8/interfaces/AggregatorProxyInterface.sol
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: MIT
++pragma solidity ^0.8.0;
++
++import "./AggregatorV2V3Interface.sol";
++
++interface AggregatorProxyInterface is AggregatorV2V3Interface {
++  function phaseAggregators(uint16 phaseId) external view returns (address);
++
++  function phaseId() external view returns (uint16);
++
++  function proposedAggregator() external view returns (address);
++
++  function proposedGetRoundData(uint80 roundId)
++    external
++    view
++    returns (
++      uint80 id,
++      int256 answer,
++      uint256 startedAt,
++      uint256 updatedAt,
++      uint80 answeredInRound
++    );
++
++  function proposedLatestRoundData()
++    external
++    view
++    returns (
++      uint80 id,
++      int256 answer,
++      uint256 startedAt,
++      uint256 updatedAt,
++      uint80 answeredInRound
++    );
++
++  function aggregator() external view returns (address);
++}

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,14 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@chainlink/contracts@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@chainlink/contracts/-/contracts-0.3.1.tgz#a1a2e1b179a6ce6a9b5b16992f6202918110ef5c"
-  integrity sha512-A8DRvmfNCwLS1iduPPj7wNAZJMe9/ZimMhoHhbbBiq+7Vq/HFjiNcdoQ5NinFdXD5aTsoNUGG5pAYKj7YMpm9A==
+"@chainlink/contracts@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@chainlink/contracts/-/contracts-0.5.1.tgz#68e7447ba8c1eccfbb760bacc93aced2eef60945"
+  integrity sha512-3PDBJ38Sd6Ml9h7FNK/tZQti+kTCdXUq1qzE6E59CnlzycsV9ElPvf2hTvs9Mi9C6pEx2Mmw9yhZMfBktYUInQ==
+  dependencies:
+    "@eth-optimism/contracts" "^0.5.21"
+    "@openzeppelin/contracts" "^4.3.3"
+    "@openzeppelin/contracts-v0.7" "npm:@openzeppelin/contracts@v3.4.2"
 
 "@codechecks/client@^0.1.10":
   version "0.1.12"
@@ -130,6 +134,37 @@
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@eth-optimism/contracts@^0.5.21":
+  version "0.5.39"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.5.39.tgz#a312a0a0b2d5853cd417c5e8969e87288e166fcb"
+  integrity sha512-u3UufuZFzgidRN2/cC3mhRxX+M6VsMV9tauIKu8D5pym5/UO4pZr85WP3KxHFfLh1i8zmkdj+pN/GRQsNYCqMg==
+  dependencies:
+    "@eth-optimism/core-utils" "0.12.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+
+"@eth-optimism/core-utils@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.12.0.tgz#6337e4599a34de23f8eceb20378de2a2de82b0ea"
+  integrity sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/providers" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bufio "^1.0.7"
+    chai "^4.3.4"
 
 "@ethereum-waffle/chai@^3.4.4":
   version "3.4.4"
@@ -549,7 +584,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
 
-"@ethersproject/contracts@5.7.0":
+"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
   integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
@@ -2082,10 +2117,20 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
+"@openzeppelin/contracts-v0.7@npm:@openzeppelin/contracts@v3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
+  integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
+
 "@openzeppelin/contracts@4.6.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
+
+"@openzeppelin/contracts@^4.3.3":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
+  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
@@ -3843,6 +3888,11 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "^4.3.0"
 
+bufio@^1.0.7:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.2.0.tgz#b9ad1c06b0d9010363c387c39d2810a7086d143f"
+  integrity sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA==
+
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
@@ -4027,7 +4077,7 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
-chai@^4.3.7:
+chai@^4.3.4, chai@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
   integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==


### PR DESCRIPTION
Creates a Chainlink Oracle which reads directly from AggregatorProxies rather than the FeedRegistry.

Couple of notes:
* For some reason the ChainlinkLibs don't expose the `AggregatorProxy` interface for Solidity version 0.8.x, so use `patch-package` to copy the 0.7 version to 0.8
* Assumes Chainlink switches over to the aggregator an Aggregator round 1, this isn't necessarily true but is a workable assumption to make for now (Screenshot from [docs](https://docs.chain.link/data-feeds/price-feeds/historical-data#roundid-in-proxy)): 
<img width="713" alt="image" src="https://user-images.githubusercontent.com/2940142/208275928-52bc977a-3593-4127-abbc-00b3ef05b8c2.png">
