### PR TITLE
Include latestVersion in updateOracle event

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,6 +125,7 @@ jobs:
         if: ${{ steps.oracleChanges.outputs.any_changed == 'true' }}
       - name: Compile
         run: yarn workspace @equilibria/perennial-oracle run compile
+        if: ${{ steps.oracleChanges.outputs.any_changed == 'true' }}
       - name: Run tests
         if: ${{ steps.oracleChanges.outputs.any_changed == 'true' }}
         env:

--- a/packages/perennial/contracts/interfaces/IPayoffProvider.sol
+++ b/packages/perennial/contracts/interfaces/IPayoffProvider.sol
@@ -6,7 +6,7 @@ import "@equilibria/perennial-oracle/contracts/interfaces/IOracleProvider.sol";
 import "./types/PayoffDefinition.sol";
 
 interface IPayoffProvider {
-    event OracleUpdated(address newOracle);
+    event OracleUpdated(address newOracle, uint256 oracleVersion);
 
     error PayoffProviderInvalidOracle();
     error PayoffProviderInvalidPayoffDefinitionError();

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -503,7 +503,7 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
      * @param newOracle new oracle address
      */
     function updateOracle(IOracleProvider newOracle) external onlyProductOwner {
-        _updateOracle(address(newOracle));
+        _updateOracle(address(newOracle), latestVersion());
     }
 
     /// @dev Limit total maker for guarded rollouts

--- a/packages/perennial/contracts/product/UPayoffProvider.sol
+++ b/packages/perennial/contracts/product/UPayoffProvider.sol
@@ -31,7 +31,7 @@ abstract contract UPayoffProvider is IPayoffProvider, UInitializable {
      */
     // solhint-disable-next-line func-name-mixedcase
     function __UPayoffProvider__initialize(IOracleProvider oracle_, PayoffDefinition calldata payoffDefinition_) internal onlyInitializer {
-        _updateOracle(address(oracle_));
+        _updateOracle(address(oracle_), 0);
 
         if (!payoffDefinition_.valid()) revert PayoffProviderInvalidPayoffDefinitionError();
         _payoffDefinition.store(payoffDefinition_);
@@ -56,12 +56,14 @@ abstract contract UPayoffProvider is IPayoffProvider, UInitializable {
 
     /**
      * @notice Updates oracle to newOracle address
+     * @param newOracle New oracle address
+     * @param oracleVersion Oracle version of update
      */
-    function _updateOracle(address newOracle) internal {
+    function _updateOracle(address newOracle, uint256 oracleVersion) internal {
         if (!Address.isContract(newOracle)) revert PayoffProviderInvalidOracle();
         _oracle.store(newOracle);
 
-        emit OracleUpdated(newOracle);
+        emit OracleUpdated(newOracle, oracleVersion);
     }
 
     /**

--- a/packages/perennial/test/unit/product/Product.test.ts
+++ b/packages/perennial/test/unit/product/Product.test.ts
@@ -188,7 +188,7 @@ describe('Product', () => {
       const newOracle = await deployMockContract(owner, IOracleProvider__factory.abi)
       await expect(product.updateOracle(newOracle.address))
         .to.emit(product, 'OracleUpdated')
-        .withArgs(newOracle.address)
+        .withArgs(newOracle.address, 0)
 
       expect(product.settle).to.have.callCount(7)
 


### PR DESCRIPTION
Include the `latestVersion` in the OracleUpdate event for better tracking.