### PR TITLE
Add DEPOSIT_TO_VAULT and WITHDRAW_FROM_VAULT to MultiInvoker

### DIFF
--- a/packages/perennial/contracts/interfaces/IMultiInvoker.sol
+++ b/packages/perennial/contracts/interfaces/IMultiInvoker.sol
@@ -22,7 +22,9 @@ interface IMultiInvoker {
         WRAP,
         UNWRAP,
         WRAP_AND_DEPOSIT,
-        WITHDRAW_AND_UNWRAP
+        WITHDRAW_AND_UNWRAP,
+        DEPOSIT_TO_VAULT,
+        WITHDRAW_FROM_VAULT
     }
 
     /// @dev Struct for action invocation

--- a/packages/perennial/package.json
+++ b/packages/perennial/package.json
@@ -35,7 +35,7 @@
     "@equilibria/emptyset-batcher": "0.0.4",
     "@equilibria/perennial-oracle": "0.1.0",
     "@equilibria/root": "0.1.6",
-    "@openzeppelin/contracts": "4.6.0"
+    "@openzeppelin/contracts": "4.8.0"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5",

--- a/packages/perennial/test/integration/multiinvoker/multiinvoker.test.ts
+++ b/packages/perennial/test/integration/multiinvoker/multiinvoker.test.ts
@@ -66,8 +66,8 @@ describe('MultiInvoker', () => {
       position = utils.parseEther('0.001')
       amount = utils.parseEther('10000')
       programs = [PROGRAM_ID.toNumber()]
-      actions = buildInvokerActions(user.address, product.address, position, amount, programs)
-      partialActions = buildInvokerActions(user.address, product.address, position.div(2), amount.div(2), programs)
+      actions = buildInvokerActions(user.address, product.address, '', position, amount, programs)
+      partialActions = buildInvokerActions(user.address, product.address, '', position.div(2), amount.div(2), programs)
     })
 
     it('does nothing on NOOP', async () => {

--- a/packages/perennial/test/util.ts
+++ b/packages/perennial/test/util.ts
@@ -14,10 +14,13 @@ export type InvokerAction =
   | 'UNWRAP'
   | 'WRAP_AND_DEPOSIT'
   | 'WITHDRAW_AND_UNWRAP'
+  | 'DEPOSIT_TO_VAULT'
+  | 'WITHDRAW_FROM_VAULT'
 
 export const buildInvokerActions = (
   userAddress: string,
   productAddress: string,
+  vaultAddress: string,
   position: BigNumberish,
   amount: BigNumberish,
   programs: number[],
@@ -70,6 +73,14 @@ export const buildInvokerActions = (
     WITHDRAW_AND_UNWRAP: {
       action: 11,
       args: utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [userAddress, productAddress, amount]),
+    },
+    DEPOSIT_TO_VAULT: {
+      action: 12,
+      args: utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [userAddress, vaultAddress, amount]),
+    },
+    WITHDRAW_FROM_VAULT: {
+      action: 13,
+      args: utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [userAddress, vaultAddress, amount]),
     },
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,6 +2087,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
+"@openzeppelin/contracts@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
+  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
Didn't add any integration tests since we don't have any vault that we can use. If we want, I can make a dummy no-op vault that's used for the integration tests.

Also, this made me realize that the balanced vault should allow withdrawals on behalf of other users from the MultiInvoker.