### PR TITLE
[Partial Fix] M05 - Explicit revert for multiple phase syncs

### DIFF
--- a/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
@@ -258,6 +258,19 @@ describe('ChainlinkFeedOracle', () => {
         expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
         expect(atVersion.version).to.equal(80)
       })
+
+      it('reverts if syncing multiple phases in a single sync call', async () => {
+        const roundId = buildChainlinkRoundId(INITIAL_PHASE + 2, 345)
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
+          .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        aggregatorProxy.getRoundData
+          .whenCalledWith(roundId)
+          .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'UnableToSyncError')
+      })
     })
   })
 


### PR DESCRIPTION
Reverts if we are trying to sync more than one phase in a single `sync` call. Note that this does not fix the underlying issue (reverts occurring) but does keep the oracle in a better state.

This is an acceptable fix for now, as the expectation for the oracle implementation is that a phase change is detected via off-chain mechanism and `sync` is called soon after.