### PR TITLE
[Fix] M06 - Handle empty phases

### DIFF
--- a/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
@@ -63,6 +63,9 @@ contract ChainlinkFeedOracle is IOracleProvider {
         // Fetch latest round
         ChainlinkRound memory round = aggregator.getLatestRound();
 
+        // Revert if the round id is 0
+        if (uint64(round.roundId) == 0) revert InvalidOracleRound();
+
         // If there is more than 1 phase to update, revert
         if (round.phaseId() - _latestPhaseId() > 1) {
             revert UnableToSyncError();

--- a/packages/perennial-oracle/contracts/ChainlinkOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkOracle.sol
@@ -61,6 +61,9 @@ contract ChainlinkOracle is IOracleProvider {
         // Fetch latest round
         ChainlinkRound memory round = registry.getLatestRound(base, quote);
 
+        // Revert if the round id is 0
+        if (uint64(round.roundId) == 0) revert InvalidOracleRound();
+
         // Update phase annotation when new phase detected
         while (round.phaseId() > _latestPhaseId()) {
             _phases.push(

--- a/packages/perennial-oracle/contracts/interfaces/IOracleProvider.sol
+++ b/packages/perennial-oracle/contracts/interfaces/IOracleProvider.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.13;
 import "@equilibria/root/number/types/Fixed18.sol";
 
 interface IOracleProvider {
+    /// @dev Error for invalid oracle round
+    error InvalidOracleRound();
+
     /// @dev A singular oracle version with its corresponding data
     struct OracleVersion {
         /// @dev The iterative version

--- a/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
@@ -48,7 +48,7 @@ library ChainlinkAggregatorLib {
 
 
     /**
-     * @notice Returns the first round ID for a specific phase ID
+     * @notice Returns the round count for the specified phase ID
      * @param self Chainlink Feed Aggregator to operate on
      * @param phaseId The specific phase to fetch data for
      * @param startingRoundId starting roundId for the aggregator proxy

--- a/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
@@ -79,7 +79,8 @@ library ChainlinkRegistryLib {
         (uint80 startingRoundId, uint80 endingRoundId) =
             FeedRegistryInterface(ChainlinkRegistry.unwrap(self)).getPhaseRange(base, quote, uint16(phaseId));
 
-        // If the phase has no rounds, then there are no rounds. Convert phase rounds to aggregator rounds to check ID
+        // If the phase has a starting and ending roundId of 0, then there are no rounds.
+        // Convert phase rounds to aggregator rounds to check ID
         if (uint64(startingRoundId) == 0 && uint64(endingRoundId) == 0) return 0;
         return uint256(endingRoundId - startingRoundId + 1);
     }

--- a/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
@@ -78,6 +78,9 @@ library ChainlinkRegistryLib {
     internal view returns (uint256) {
         (uint80 startingRoundId, uint80 endingRoundId) =
             FeedRegistryInterface(ChainlinkRegistry.unwrap(self)).getPhaseRange(base, quote, uint16(phaseId));
+
+        // If the phase has no rounds, then there are no rounds. Convert phase rounds to aggregator rounds to check ID
+        if (uint64(startingRoundId) == 0 && uint64(endingRoundId) == 0) return 0;
         return uint256(endingRoundId - startingRoundId + 1);
     }
 }

--- a/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
@@ -265,11 +265,16 @@ describe('ChainlinkFeedOracle', () => {
           .whenCalledWith()
           .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
 
-        aggregatorProxy.getRoundData
-          .whenCalledWith(roundId)
+        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'UnableToSyncError')
+      })
+
+      it('reverts on invalid round', async () => {
+        const roundId = buildChainlinkRoundId(INITIAL_PHASE + 1, 0)
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
           .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
 
-        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'UnableToSyncError')
+        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'InvalidOracleRound')
       })
     })
   })

--- a/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkFeedOracle/ChainlinkFeedOracle.test.ts
@@ -258,6 +258,19 @@ describe('ChainlinkFeedOracle', () => {
         expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
         expect(atVersion.version).to.equal(80)
       })
+
+      it('reverts if syncing multiple phases in a single sync call', async () => {
+        const roundId = buildChainlinkRoundId(INITIAL_PHASE + 2, 345)
+        aggregatorProxy.latestRoundData
+          .whenCalledWith()
+          .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        aggregatorProxy.getRoundData
+          .whenCalledWith(roundId)
+          .returns([roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId])
+
+        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'UnableToSyncError')
+      })
     })
   })
 

--- a/packages/perennial-oracle/test/unit/ChainlinkOracle/ChainlinkOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkOracle/ChainlinkOracle.test.ts
@@ -175,6 +175,42 @@ describe('ChainlinkOracle', () => {
         expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
         expect(atVersion.version).to.equal(426)
       })
+
+      it('syncs with an empty phase', async () => {
+        await registry.mock.getPhaseRange
+          .withArgs(eth.address, usd.address, 2)
+          .returns(buildChainlinkRoundId(2, 0), buildChainlinkRoundId(2, 0))
+
+        await registry.mock.getPhaseRange
+          .withArgs(eth.address, usd.address, 3)
+          .returns(buildChainlinkRoundId(3, 320), buildChainlinkRoundId(3, 700))
+
+        const roundId = buildChainlinkRoundId(3, 345)
+        await registry.mock.latestRoundData
+          .withArgs(eth.address, usd.address)
+          .returns(roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId)
+
+        await registry.mock.getRoundData
+          .withArgs(eth.address, usd.address, roundId)
+          .returns(roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId)
+
+        const returnValue = await oracle.callStatic.sync()
+        await oracle.connect(user).sync()
+
+        expect(returnValue.price).to.equal(utils.parseEther('1333'))
+        expect(returnValue.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(returnValue.version).to.equal(426)
+
+        const currentVersion = await oracle.currentVersion()
+        expect(currentVersion.price).to.equal(utils.parseEther('1333'))
+        expect(currentVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(currentVersion.version).to.equal(426)
+
+        const atVersion = await oracle.atVersion(426)
+        expect(atVersion.price).to.equal(utils.parseEther('1333'))
+        expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
+        expect(atVersion.version).to.equal(426)
+      })
     })
   })
 
@@ -276,6 +312,81 @@ describe('ChainlinkOracle', () => {
       expect(atVersion3.price).to.equal(utils.parseEther('2111'))
       expect(atVersion3.timestamp).to.equal(TIMESTAMP_START - 1 * HOUR)
       expect(atVersion3.version).to.equal(701)
+    })
+
+    it('reads versions in multiple phases with empty phase', async () => {
+      const currentRoundId = buildChainlinkRoundId(4, 350)
+
+      await registry.mock.getPhaseRange
+        .withArgs(eth.address, usd.address, 2)
+        .returns(buildChainlinkRoundId(2, 301), buildChainlinkRoundId(2, 600))
+      await registry.mock.getPhaseRange
+        .withArgs(eth.address, usd.address, 3)
+        .returns(buildChainlinkRoundId(3, 0), buildChainlinkRoundId(3, 0))
+      await registry.mock.getPhaseRange
+        .withArgs(eth.address, usd.address, 4)
+        .returns(buildChainlinkRoundId(4, 100), buildChainlinkRoundId(4, 500))
+
+      await registry.mock.latestRoundData
+        .withArgs(eth.address, usd.address)
+        .returns(
+          currentRoundId,
+          ethers.BigNumber.from(111100000000),
+          TIMESTAMP_START - HOUR,
+          TIMESTAMP_START,
+          currentRoundId,
+        )
+
+      // Syncs from Phase 1 to Phase 4
+      await oracle.connect(user).sync()
+
+      // Check Version from Phase 1: Versions 0 to 400
+      const roundIdPhase1 = buildChainlinkRoundId(1, 112)
+      await registry.mock.getRoundData
+        .withArgs(eth.address, usd.address, roundIdPhase1)
+        .returns(
+          roundIdPhase1,
+          ethers.BigNumber.from(111100000000),
+          TIMESTAMP_START - 6 * HOUR,
+          TIMESTAMP_START - 5 * HOUR,
+          roundIdPhase1,
+        )
+      const atVersionPhase1 = await oracle.atVersion(12)
+      expect(atVersionPhase1.price).to.equal(utils.parseEther('1111'))
+      expect(atVersionPhase1.timestamp).to.equal(TIMESTAMP_START - 5 * HOUR)
+      expect(atVersionPhase1.version).to.equal(12)
+
+      // Check Version from Phase 2: Versions 401 to 700
+      const roundIdPhase2 = buildChainlinkRoundId(2, 600)
+      await registry.mock.getRoundData
+        .withArgs(eth.address, usd.address, roundIdPhase2)
+        .returns(
+          roundIdPhase2,
+          ethers.BigNumber.from(123400000000),
+          TIMESTAMP_START - 3 * HOUR,
+          TIMESTAMP_START - 2 * HOUR,
+          roundIdPhase2,
+        )
+      const atVersion2 = await oracle.atVersion(700)
+      expect(atVersion2.price).to.equal(utils.parseEther('1234'))
+      expect(atVersion2.timestamp).to.equal(TIMESTAMP_START - 2 * HOUR)
+      expect(atVersion2.version).to.equal(700)
+
+      // Check Version from Phase 4: Versions 701 onwards
+      const roundIdPhase4 = buildChainlinkRoundId(4, 100)
+      await registry.mock.getRoundData
+        .withArgs(eth.address, usd.address, roundIdPhase4)
+        .returns(
+          roundIdPhase4,
+          ethers.BigNumber.from(211100000000),
+          TIMESTAMP_START - 2 * HOUR,
+          TIMESTAMP_START - 1 * HOUR,
+          roundIdPhase4,
+        )
+      const atVersion4 = await oracle.atVersion(701)
+      expect(atVersion4.price).to.equal(utils.parseEther('2111'))
+      expect(atVersion4.timestamp).to.equal(TIMESTAMP_START - 1 * HOUR)
+      expect(atVersion4.version).to.equal(701)
     })
   })
 })

--- a/packages/perennial-oracle/test/unit/ChainlinkOracle/ChainlinkOracle.test.ts
+++ b/packages/perennial-oracle/test/unit/ChainlinkOracle/ChainlinkOracle.test.ts
@@ -211,6 +211,15 @@ describe('ChainlinkOracle', () => {
         expect(atVersion.timestamp).to.equal(TIMESTAMP_START + HOUR)
         expect(atVersion.version).to.equal(426)
       })
+
+      it('reverts on invalid round', async () => {
+        const roundId = buildChainlinkRoundId(2, 0)
+        await registry.mock.latestRoundData
+          .withArgs(eth.address, usd.address)
+          .returns(roundId, ethers.BigNumber.from(133300000000), TIMESTAMP_START, TIMESTAMP_START + HOUR, roundId)
+
+        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'InvalidOracleRound')
+      })
     })
   })
 


### PR DESCRIPTION
In the event that we sync with an intermediary phase that is empty, we should correctly mark that the number of rounds in the phase is 0 (instead of 1)