### PR TITLE
Additional BalancedVault testing

### DIFF
--- a/packages/perennial-vaults/contracts/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/BalancedVault.sol
@@ -398,12 +398,12 @@ contract BalancedVault is IBalancedVault, UInitializable {
      * @notice Rebalances the position of the vault
      */
     function _rebalancePosition(VersionContext memory context, UFixed18 claimAmount) private {
-        UFixed18 currentAssets = _totalAssetsAtVersion(context).add(_deposit).sub(claimAmount);
-        if (currentAssets.lt(controller.minCollateral().mul(TWO))) currentAssets = UFixed18Lib.ZERO;
-
+        UFixed18 currentAssets = _totalAssetsAtVersion(context).sub(claimAmount);
         UFixed18 currentUtilized = _totalSupply.add(_redemption).isZero() ?
-            currentAssets :
-            currentAssets.muldiv(_totalSupply, _totalSupply.add(_redemption));
+            _deposit.add(currentAssets) :
+            _deposit.add(currentAssets.muldiv(_totalSupply, _totalSupply.add(_redemption)));
+        if (currentUtilized.lt(controller.minCollateral().mul(TWO))) currentUtilized = UFixed18Lib.ZERO;
+
         UFixed18 currentPrice = long.atVersion(context.version).price.abs();
         UFixed18 targetPosition = currentUtilized.mul(targetLeverage).div(currentPrice).div(TWO);
 

--- a/packages/perennial-vaults/contracts/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/BalancedVault.sol
@@ -177,15 +177,17 @@ contract BalancedVault is IBalancedVault, UInitializable {
     function claim(address account) external {
         (VersionContext memory context, ) = _settle(account);
 
-        UFixed18 claimAmount = _unclaimed[account];
+        UFixed18 unclaimedAmount = _unclaimed[account];
+        UFixed18 unclaimedTotal = _totalUnclaimed;
         _unclaimed[account] = UFixed18Lib.ZERO;
-        _totalUnclaimed = _totalUnclaimed.sub(claimAmount);
-        emit Claim(msg.sender, account, claimAmount);
+        _totalUnclaimed = unclaimedTotal.sub(unclaimedAmount);
+        emit Claim(msg.sender, account, unclaimedAmount);
 
         // pro-rate if vault has less collateral than unclaimed
+        UFixed18 claimAmount = unclaimedAmount;
         (UFixed18 longCollateral, UFixed18 shortCollateral, UFixed18 idleCollateral) = _collateral();
         UFixed18 totalCollateral = longCollateral.add(shortCollateral).add(idleCollateral);
-        if (totalCollateral.lt(_totalUnclaimed)) claimAmount = claimAmount.muldiv(totalCollateral, _totalUnclaimed);
+        if (totalCollateral.lt(unclaimedTotal)) claimAmount = claimAmount.muldiv(totalCollateral, unclaimedTotal);
 
         _rebalance(context, claimAmount);
 
@@ -350,6 +352,8 @@ contract BalancedVault is IBalancedVault, UInitializable {
                 longPosition: long.position(address(this)).maker,
                 shortPosition: short.position(address(this)).maker,
                 totalShares: _totalSupply,
+                longAssets: collateral.collateral(address(this), long),
+                shortAssets: collateral.collateral(address(this), short),
                 totalAssets: _totalAssetsAtVersion(context)
             });
         }
@@ -636,18 +640,24 @@ contract BalancedVault is IBalancedVault, UInitializable {
 
     /**
      * @notice The total assets at the given version
-     * @dev Calculates and adds accumualted PnL for `version` + 1
+     * @dev Calculates and adds accumulated PnL for `version` + 1
      * @param version Version to get total assets at
      * @return Total assets in the vault at the given version
      */
     function _assetsAt(uint256 version) private view returns (UFixed18) {
-        Fixed18 longAccumulated = long.valueAtVersion(version + 1).maker.sub(long.valueAtVersion(version).maker);
-        Fixed18 shortAccumulated = short.valueAtVersion(version + 1).maker.sub(short.valueAtVersion(version).maker);
+        Fixed18 longAccumulated = long.valueAtVersion(version + 1).maker.sub(long.valueAtVersion(version).maker)
+            .mul(Fixed18Lib.from(_versions[version].longPosition))
+            .max(Fixed18Lib.from(_versions[version].longAssets).mul(Fixed18Lib.NEG_ONE));  // collateral can't go negative on a product
+        Fixed18 shortAccumulated = short.valueAtVersion(version + 1).maker.sub(short.valueAtVersion(version).maker)
+            .mul(Fixed18Lib.from(_versions[version].shortPosition))
+            .max(Fixed18Lib.from(_versions[version].shortAssets).mul(Fixed18Lib.NEG_ONE)); // collateral can't go negative on a product
 
-        Fixed18 accumulated = longAccumulated.mul(Fixed18Lib.from(_versions[version].longPosition))
-            .add(shortAccumulated.mul(Fixed18Lib.from(_versions[version].shortPosition)));
-
-        return UFixed18Lib.from(Fixed18Lib.from(_versions[version].totalAssets).add(accumulated).max(Fixed18Lib.ZERO));
+        return UFixed18Lib.from(
+            Fixed18Lib.from(_versions[version].totalAssets)
+                .add(longAccumulated)
+                .add(shortAccumulated)
+                .max(Fixed18Lib.ZERO) // vault can't have negative assets, socializes into unclaimed if triggered
+        );
     }
 
     /**

--- a/packages/perennial-vaults/contracts/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/BalancedVault.sol
@@ -313,6 +313,8 @@ contract BalancedVault is IBalancedVault, UInitializable {
      */
     function convertToShares(UFixed18 assets) external view returns (UFixed18) {
         (VersionContext memory context, ) = _loadContextForRead(address(0));
+        (context.latestCollateral, context.latestShares) =
+            (_totalAssetsAtVersion(context), _totalSupplyAtVersion(context));
         return _convertToSharesAtVersion(context, assets);
     }
 
@@ -323,6 +325,8 @@ contract BalancedVault is IBalancedVault, UInitializable {
      */
     function convertToAssets(UFixed18 shares) external view returns (UFixed18) {
         (VersionContext memory context, ) = _loadContextForRead(address(0));
+        (context.latestCollateral, context.latestShares) =
+            (_totalAssetsAtVersion(context), _totalSupplyAtVersion(context));
         return _convertToAssetsAtVersion(context, shares);
     }
 

--- a/packages/perennial-vaults/contracts/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/BalancedVault.sol
@@ -533,10 +533,10 @@ contract BalancedVault is IBalancedVault, UInitializable {
      */
     function _unhealthyAtVersion(VersionContext memory context) private view returns (bool) {
         return collateral.liquidatable(address(this), long)
-        || collateral.liquidatable(address(this), short)
-        || long.isLiquidating(address(this))
-        || short.isLiquidating(address(this))
-        || (!context.latestShares.isZero() && context.latestCollateral.isZero());
+            || collateral.liquidatable(address(this), short)
+            || long.isLiquidating(address(this))
+            || short.isLiquidating(address(this))
+            || (!context.latestShares.isZero() && context.latestCollateral.isZero());
     }
 
     /**

--- a/packages/perennial-vaults/contracts/interfaces/IBalancedVault.sol
+++ b/packages/perennial-vaults/contracts/interfaces/IBalancedVault.sol
@@ -13,6 +13,8 @@ interface IBalancedVault {
         UFixed18 longPosition;
         UFixed18 shortPosition;
         UFixed18 totalShares;
+        UFixed18 longAssets;
+        UFixed18 shortAssets;
         UFixed18 totalAssets;
     }
 

--- a/packages/perennial-vaults/test/integration/balancedVault.test.ts
+++ b/packages/perennial-vaults/test/integration/balancedVault.test.ts
@@ -422,6 +422,81 @@ describe('BalancedVault', () => {
       expect(await vault.totalUnclaimed()).to.equal(0)
     })
 
+    it('deposit during withdraw', async () => {
+      expect(await vault.convertToAssets(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+      expect(await vault.convertToShares(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+
+      const smallDeposit = utils.parseEther('1000')
+      await vault.connect(user).deposit(smallDeposit, user.address)
+      await updateOracle()
+      await vault.sync()
+
+      const largeDeposit = utils.parseEther('2000')
+      await vault.connect(user2).deposit(largeDeposit, user2.address)
+      await vault.connect(user).redeem(utils.parseEther('400'), user.address)
+      await updateOracle()
+      await vault.sync()
+
+      // Now we should have opened positions.
+      // The positions should be equal to (smallDeposit + largeDeposit) * leverage / 2 / originalOraclePrice.
+      expect(await longPosition()).to.be.equal(
+        smallDeposit.add(largeDeposit).sub(utils.parseEther('400')).mul(leverage).div(2).div(originalOraclePrice),
+      )
+      expect(await shortPosition()).to.equal(
+        smallDeposit.add(largeDeposit).sub(utils.parseEther('400')).mul(leverage).div(2).div(originalOraclePrice),
+      )
+      const fundingAmount0 = BigNumber.from('93756866841')
+      const balanceOf2 = BigNumber.from('1999999999687477110578')
+      expect(await vault.balanceOf(user.address)).to.equal(utils.parseEther('600'))
+      expect(await vault.balanceOf(user2.address)).to.equal(balanceOf2)
+      expect(await vault.totalAssets()).to.equal(utils.parseEther('2600').add(fundingAmount0))
+      expect(await vault.totalSupply()).to.equal(utils.parseEther('600').add(balanceOf2))
+      expect(await vault.convertToAssets(utils.parseEther('600').add(balanceOf2))).to.equal(
+        utils.parseEther('2600').add(fundingAmount0),
+      )
+      expect(await vault.convertToShares(utils.parseEther('2600').add(fundingAmount0))).to.equal(
+        utils.parseEther('600').add(balanceOf2),
+      )
+
+      const maxRedeem = await vault.maxRedeem(user.address)
+      await vault.connect(user).redeem(maxRedeem, user.address)
+      await updateOracle()
+      await vault.sync()
+
+      const maxRedeem2 = await vault.maxRedeem(user2.address)
+      await vault.connect(user2).redeem(maxRedeem2, user2.address)
+      await updateOracle()
+      await vault.sync()
+
+      // We should have closed all positions.
+      expect(await longPosition()).to.equal(0)
+      expect(await shortPosition()).to.equal(0)
+
+      // We should have withdrawn all of our collateral.
+      const fundingAmount = BigNumber.from('249607634342')
+      const fundingAmount2 = BigNumber.from('622820158534')
+      expect(await totalCollateralInVault()).to.equal(utils.parseEther('3000').add(fundingAmount).add(fundingAmount2))
+      expect(await vault.balanceOf(user.address)).to.equal(0)
+      expect(await vault.balanceOf(user2.address)).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      expect(await vault.totalSupply()).to.equal(0)
+      expect(await vault.convertToAssets(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+      expect(await vault.convertToShares(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+      expect(await vault.unclaimed(user.address)).to.equal(utils.parseEther('1000').add(fundingAmount))
+      expect(await vault.unclaimed(user2.address)).to.equal(utils.parseEther('2000').add(fundingAmount2))
+      expect(await vault.totalUnclaimed()).to.equal(utils.parseEther('3000').add(fundingAmount).add(fundingAmount2))
+
+      await vault.connect(user).claim(user.address)
+      await vault.connect(user2).claim(user2.address)
+
+      expect(await totalCollateralInVault()).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      expect(await asset.balanceOf(user.address)).to.equal(utils.parseEther('200000').add(fundingAmount))
+      expect(await asset.balanceOf(user2.address)).to.equal(utils.parseEther('200000').add(fundingAmount2))
+      expect(await vault.unclaimed(user2.address)).to.equal(0)
+      expect(await vault.totalUnclaimed()).to.equal(0)
+    })
+
     it('transferring shares', async () => {
       const smallDeposit = utils.parseEther('10')
       await vault.connect(user).deposit(smallDeposit, user.address)

--- a/packages/perennial-vaults/test/integration/balancedVault.test.ts
+++ b/packages/perennial-vaults/test/integration/balancedVault.test.ts
@@ -334,7 +334,6 @@ describe('BalancedVault', () => {
       const fundingAmount = BigNumber.from('1526207855124')
       expect(await totalCollateralInVault()).to.equal(utils.parseEther('10010').add(fundingAmount))
       expect(await vault.balanceOf(user.address)).to.equal(0)
-      expect(await vault.balanceOf(user2.address)).to.equal(0)
       expect(await vault.totalSupply()).to.equal(0)
       expect(await vault.totalAssets()).to.equal(0)
       expect(await vault.convertToAssets(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
@@ -345,6 +344,8 @@ describe('BalancedVault', () => {
       await vault.connect(user).claim(user.address)
       expect(await totalCollateralInVault()).to.equal(0)
       expect(await asset.balanceOf(user.address)).to.equal(utils.parseEther('200000').add(fundingAmount))
+      expect(await vault.unclaimed(user.address)).to.equal(0)
+      expect(await vault.totalUnclaimed()).to.equal(0)
     })
 
     it('multiple users', async () => {
@@ -417,6 +418,8 @@ describe('BalancedVault', () => {
       expect(await vault.totalAssets()).to.equal(0)
       expect(await asset.balanceOf(user.address)).to.equal(utils.parseEther('200000').add(fundingAmount))
       expect(await asset.balanceOf(user2.address)).to.equal(utils.parseEther('200000').add(fundingAmount2))
+      expect(await vault.unclaimed(user2.address)).to.equal(0)
+      expect(await vault.totalUnclaimed()).to.equal(0)
     })
 
     it('transferring shares', async () => {


### PR DESCRIPTION
Adds additional integration tests for the `BalancedVault`.

Fixes the following issues:

- Incorrect version of collateral and shares used in the exchange rate computation for `convertSharesToAssets` and `convertAssetsToShares` getters.
  - Fix: Switched from the `latestVersion` snapshot, to the *current* values.
- Incorrect handling of the unclaimed socialization during an insolvency event
  - Fix: Add `shortAssets` and `longAssets` to the version snapshot so that we can track shortfall events per product upon accumulation in `_assetsAt()`
  - Fix: Reorganize logic in `claim()` to properly compute the socialized `claimAmount`