### PR TITLE
[WP-M1] Fix position targeting

### DIFF
--- a/packages/perennial-vaults/contracts/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/BalancedVault.sol
@@ -398,12 +398,12 @@ contract BalancedVault is IBalancedVault, UInitializable {
      * @notice Rebalances the position of the vault
      */
     function _rebalancePosition(VersionContext memory context, UFixed18 claimAmount) private {
-        UFixed18 currentAssets = _totalAssetsAtVersion(context).add(_deposit).sub(claimAmount);
-        if (currentAssets.lt(controller.minCollateral().mul(TWO))) currentAssets = UFixed18Lib.ZERO;
-
+        UFixed18 currentAssets = _totalAssetsAtVersion(context).sub(claimAmount);
         UFixed18 currentUtilized = _totalSupply.add(_redemption).isZero() ?
-            currentAssets :
-            currentAssets.muldiv(_totalSupply, _totalSupply.add(_redemption));
+            _deposit.add(currentAssets) :
+            _deposit.add(currentAssets.muldiv(_totalSupply, _totalSupply.add(_redemption)));
+        if (currentUtilized.lt(controller.minCollateral().mul(TWO))) currentUtilized = UFixed18Lib.ZERO;
+
         UFixed18 currentPrice = long.atVersion(context.version).price.abs();
         UFixed18 targetPosition = currentUtilized.mul(targetLeverage).div(currentPrice).div(TWO);
 

--- a/packages/perennial-vaults/test/integration/balancedVault.test.ts
+++ b/packages/perennial-vaults/test/integration/balancedVault.test.ts
@@ -422,6 +422,81 @@ describe('BalancedVault', () => {
       expect(await vault.totalUnclaimed()).to.equal(0)
     })
 
+    it('deposit during withdraw', async () => {
+      expect(await vault.convertToAssets(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+      expect(await vault.convertToShares(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+
+      const smallDeposit = utils.parseEther('1000')
+      await vault.connect(user).deposit(smallDeposit, user.address)
+      await updateOracle()
+      await vault.sync()
+
+      const largeDeposit = utils.parseEther('2000')
+      await vault.connect(user2).deposit(largeDeposit, user2.address)
+      await vault.connect(user).redeem(utils.parseEther('400'), user.address)
+      await updateOracle()
+      await vault.sync()
+
+      // Now we should have opened positions.
+      // The positions should be equal to (smallDeposit + largeDeposit) * leverage / 2 / originalOraclePrice.
+      expect(await longPosition()).to.be.equal(
+        smallDeposit.add(largeDeposit).sub(utils.parseEther('400')).mul(leverage).div(2).div(originalOraclePrice),
+      )
+      expect(await shortPosition()).to.equal(
+        smallDeposit.add(largeDeposit).sub(utils.parseEther('400')).mul(leverage).div(2).div(originalOraclePrice),
+      )
+      const fundingAmount0 = BigNumber.from('93756866841')
+      const balanceOf2 = BigNumber.from('1999999999687477110578')
+      expect(await vault.balanceOf(user.address)).to.equal(utils.parseEther('600'))
+      expect(await vault.balanceOf(user2.address)).to.equal(balanceOf2)
+      expect(await vault.totalAssets()).to.equal(utils.parseEther('2600').add(fundingAmount0))
+      expect(await vault.totalSupply()).to.equal(utils.parseEther('600').add(balanceOf2))
+      expect(await vault.convertToAssets(utils.parseEther('600').add(balanceOf2))).to.equal(
+        utils.parseEther('2600').add(fundingAmount0),
+      )
+      expect(await vault.convertToShares(utils.parseEther('2600').add(fundingAmount0))).to.equal(
+        utils.parseEther('600').add(balanceOf2),
+      )
+
+      const maxRedeem = await vault.maxRedeem(user.address)
+      await vault.connect(user).redeem(maxRedeem, user.address)
+      await updateOracle()
+      await vault.sync()
+
+      const maxRedeem2 = await vault.maxRedeem(user2.address)
+      await vault.connect(user2).redeem(maxRedeem2, user2.address)
+      await updateOracle()
+      await vault.sync()
+
+      // We should have closed all positions.
+      expect(await longPosition()).to.equal(0)
+      expect(await shortPosition()).to.equal(0)
+
+      // We should have withdrawn all of our collateral.
+      const fundingAmount = BigNumber.from('249607634342')
+      const fundingAmount2 = BigNumber.from('622820158534')
+      expect(await totalCollateralInVault()).to.equal(utils.parseEther('3000').add(fundingAmount).add(fundingAmount2))
+      expect(await vault.balanceOf(user.address)).to.equal(0)
+      expect(await vault.balanceOf(user2.address)).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      expect(await vault.totalSupply()).to.equal(0)
+      expect(await vault.convertToAssets(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+      expect(await vault.convertToShares(utils.parseEther('1'))).to.equal(utils.parseEther('1'))
+      expect(await vault.unclaimed(user.address)).to.equal(utils.parseEther('1000').add(fundingAmount))
+      expect(await vault.unclaimed(user2.address)).to.equal(utils.parseEther('2000').add(fundingAmount2))
+      expect(await vault.totalUnclaimed()).to.equal(utils.parseEther('3000').add(fundingAmount).add(fundingAmount2))
+
+      await vault.connect(user).claim(user.address)
+      await vault.connect(user2).claim(user2.address)
+
+      expect(await totalCollateralInVault()).to.equal(0)
+      expect(await vault.totalAssets()).to.equal(0)
+      expect(await asset.balanceOf(user.address)).to.equal(utils.parseEther('200000').add(fundingAmount))
+      expect(await asset.balanceOf(user2.address)).to.equal(utils.parseEther('200000').add(fundingAmount2))
+      expect(await vault.unclaimed(user2.address)).to.equal(0)
+      expect(await vault.totalUnclaimed()).to.equal(0)
+    })
+
     it('transferring shares', async () => {
       const smallDeposit = utils.parseEther('10')
       await vault.connect(user).deposit(smallDeposit, user.address)


### PR DESCRIPTION
`currentUtilized` is supposed to represent the *best guess* at the amount of collateral available in the vault next version net of any unclaimed.

- This moves deposits outside of the redemption pro-rata calculation, since these will not be affected by the current versions withdrawals.
- Also modifies the `minCollateral` check to use this newly corrected `currentUtilized`
- Adds test case to verify this change