### PR TITLE
Chainlink Bisection Oracle for Phase Discovery

### DIFF
--- a/packages/perennial-oracle/contracts/test/PassthroughDataFeed.sol
+++ b/packages/perennial-oracle/contracts/test/PassthroughDataFeed.sol
@@ -6,6 +6,16 @@ import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 contract PassthroughDataFeed {
     AggregatorV3Interface private _underlying;
 
+    struct LatestRoundData {
+        uint80 roundId;
+        int256 answer;
+        uint256 startedAt;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+    }
+
+    LatestRoundData private _roundOverride;
+
     constructor(AggregatorV3Interface underlying_) {
         _underlying = underlying_;
     }
@@ -19,6 +29,29 @@ contract PassthroughDataFeed {
     }
 
     function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
+        if (_roundOverride.roundId != 0) return (
+            _roundOverride.roundId,
+            _roundOverride.answer,
+            _roundOverride.startedAt,
+            _roundOverride.updatedAt,
+            _roundOverride.answeredInRound
+        );
         return _underlying.latestRoundData();
+    }
+
+    function _setLatestRoundData(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external  {
+        _roundOverride = LatestRoundData(
+            roundId,
+            answer,
+            startedAt,
+            updatedAt,
+            answeredInRound
+        );
     }
 }

--- a/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkAggregator.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorProxyInterface.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./ChainlinkRound.sol";
 
 /// @dev ChainlinkAggregator type
@@ -79,17 +80,91 @@ library ChainlinkAggregatorLib {
             // pass
         }
 
-        // lastSyncedRound is the last round it's phase before latestRound, so we need to find where the next phase starts
+        // lastSyncedRound is the last round in it's phase before latestRound, so we need to find where the next phase starts
         // The next phase should start at the round that is closest to but after lastSyncedRound.timestamp
-        (,,,uint256 lastSyncedRoundTimestamp,) = proxy.getRoundData(uint80(lastSyncedRoundId));
-        nextPhaseStartingRoundId = latestRound.roundId;
-        uint256 updatedAt = latestRound.timestamp;
-        // Walk back in the new phase until we dip below the lastSyncedRound.timestamp
-        while (updatedAt >= lastSyncedRoundTimestamp) {
-            nextPhaseStartingRoundId--;
-            (,,,updatedAt,) = proxy.getRoundData(uint80(nextPhaseStartingRoundId));
+        ChainlinkRound memory lastSyncedRound = getRound(self, lastSyncedRoundId);
+        uint16 phaseToSearch = lastSyncedRound.phaseId() + 1;
+        while (nextPhaseStartingRoundId == 0) {
+            nextPhaseStartingRoundId = getStartingRoundId(self, phaseToSearch, lastSyncedRound.timestamp);
+            phaseToSearch += 1;
         }
 
-        return ((lastSyncedRoundId - startingRoundId) + 1, nextPhaseStartingRoundId + 1);
+        return ((lastSyncedRoundId - startingRoundId) + 1, nextPhaseStartingRoundId);
+    }
+
+    /**
+     * @notice Returns the round ID closest to but greater than targetTimestamp for the specified phase ID
+     * @param self Chainlink Feed Aggregator to operate on
+     * @param phaseId The specific phase to fetch data for
+     * @param targetTimestamp timestamp to search for
+     * @dev Assumes the phase ends at the aggregators latestRound or earlier
+     * @return The number of rounds in the phase
+     */
+    function getStartingRoundId(ChainlinkAggregator self, uint16 phaseId, uint256 targetTimestamp)
+    internal view returns (uint256) {
+        AggregatorProxyInterface proxy = AggregatorProxyInterface(ChainlinkAggregator.unwrap(self));
+
+        (,,,uint256 startTimestamp,) = proxy.getRoundData(uint80(_aggregatorRoundIdToProxyRoundId(phaseId, 1)));
+        if (startTimestamp == 0) return 0; // Empty phase
+
+        return _search(proxy, phaseId, targetTimestamp, startTimestamp, 1);
+    }
+
+    /**
+     * Searches the given chainlink proxy for a round which has a timestamp which is as close to but greater than
+     * the `targetTimestamp`
+     * @param proxy Chainlink Proxy to search within
+     * @param phaseId Phase to search for round
+     * @param targetTimestamp Minimum timestamp value for found round
+     * @param minTimestamp Starting timestamp value
+     * @param minRoundId Starting round ID
+     */
+    function _search(AggregatorProxyInterface proxy, uint16 phaseId, uint256 targetTimestamp, uint256 minTimestamp, uint256 minRoundId) private view returns (uint256) {
+        uint256 maxRoundId = minRoundId + 1000; // Start 1000 rounds away when searching for maximum
+        uint256 maxTimestamp = _tryGetProxyRoundData(proxy, phaseId, uint80(maxRoundId));
+        while (maxTimestamp < targetTimestamp) {
+            minRoundId = maxRoundId;
+            minTimestamp = maxTimestamp;
+            maxRoundId = maxRoundId * 2; // Find bounds of phase by multiplying the max round by 2
+            maxTimestamp = _tryGetProxyRoundData(proxy, phaseId, uint80(maxRoundId));
+        }
+
+        while (minRoundId + 1 < maxRoundId) {
+            uint256 midRound = Math.average(minRoundId, maxRoundId);
+            uint256 midTimestamp = _tryGetProxyRoundData(proxy, phaseId, uint80(midRound));
+            if (midTimestamp > targetTimestamp) {
+                maxTimestamp = midTimestamp;
+                maxRoundId = midRound;
+            } else {
+                minTimestamp = midTimestamp;
+                minRoundId = midRound;
+            }
+        }
+
+        // If the found timestamp is not greater than target timestamp, then the desired round does
+        // not exist in this phase
+        if (maxTimestamp <= targetTimestamp) return 0;
+
+        return _aggregatorRoundIdToProxyRoundId(phaseId, uint80(maxRoundId));
+    }
+
+    function _tryGetProxyRoundData(AggregatorProxyInterface proxy, uint16 phaseId, uint80 tryRound) private view returns (uint256) {
+        try proxy.getRoundData(uint80(_aggregatorRoundIdToProxyRoundId(phaseId, tryRound))) returns (uint80,int256,uint256,uint256 timestamp,uint80) {
+            if (timestamp > 0) return timestamp;
+        } catch  {
+            // pass
+        }
+        return type(uint256).max;
+    }
+
+    /**
+     * @notice Convert an aggregator round ID into a proxy round ID for the given phase
+     * @dev Follows the logic specified in https://docs.chain.link/data-feeds/price-feeds/historical-data#roundid-in-proxy
+     * @param phaseId phase ID for the given aggregator round
+     * @param aggregatorRoundId round id for the aggregator round
+     * @return Proxy roundId
+     */
+    function _aggregatorRoundIdToProxyRoundId(uint16 phaseId, uint80 aggregatorRoundId) private pure returns (uint256) {
+        return (uint256(phaseId) << 64) + aggregatorRoundId;
     }
 }

--- a/packages/perennial-oracle/test/integration/ChainlinkFeedOracle/ChainlinkFeedOracle.integrationTest.ts
+++ b/packages/perennial-oracle/test/integration/ChainlinkFeedOracle/ChainlinkFeedOracle.integrationTest.ts
@@ -1,5 +1,4 @@
-import { smock, FakeContract } from '@defi-wonderland/smock'
-import { BigNumber, utils } from 'ethers'
+import { smock, MockContract } from '@defi-wonderland/smock'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import HRE from 'hardhat'
@@ -9,19 +8,14 @@ import {
   ChainlinkFeedOracle__factory,
   AggregatorProxyInterface,
   AggregatorProxyInterface__factory,
+  PassthroughDataFeed,
+  PassthroughDataFeed__factory,
 } from '../../../types/generated'
 import { reset } from '../../../../common/testutil/time'
 import { buildChainlinkRoundId } from '../../../util'
 
 const { ethers, config } = HRE
 
-type ChainlinkRound = [BigNumber, BigNumber, BigNumber, BigNumber, BigNumber] & {
-  roundId: BigNumber
-  answer: BigNumber
-  startedAt: BigNumber
-  updatedAt: BigNumber
-  answeredInRound: BigNumber
-}
 const PHASE_3_STARTING_ROUND = buildChainlinkRoundId(3, 1234)
 const PHASE_4_STARTING_ROUND = buildChainlinkRoundId(4, 543)
 const PHASE_5_STARTING_ROUND = buildChainlinkRoundId(5, 756)
@@ -31,53 +25,35 @@ describe('ChainlinkFeedOracle', () => {
   let user: SignerWithAddress
 
   let aggregatorProxy: AggregatorProxyInterface
-  let aggregatorFake: FakeContract<AggregatorProxyInterface>
+  let aggregatorMock: MockContract<PassthroughDataFeed>
   let oracle: ChainlinkFeedOracle
-  const phase3Data: ChainlinkRound[] = []
-  const phase4Data: ChainlinkRound[] = []
-  const phase5Data: ChainlinkRound[] = []
-
   beforeEach(async () => {
     await reset(config)
     ;[owner, user] = await ethers.getSigners()
+    const aggregatorMockFactory = await smock.mock<PassthroughDataFeed__factory>('PassthroughDataFeed')
+
     aggregatorProxy = await AggregatorProxyInterface__factory.connect(
       '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419',
       owner,
     )
-    aggregatorFake = await smock.fake<AggregatorProxyInterface>(AggregatorProxyInterface__factory.abi)
-    aggregatorFake.decimals.returns(await aggregatorProxy.decimals())
+    aggregatorMock = await aggregatorMockFactory.deploy(aggregatorProxy.address)
+    const latestData3 = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND)
+    // This is necessary because smock's mocking is buggy for some reason, likely due to naming collisions
+    await aggregatorMock._setLatestRoundData(...latestData3)
 
-    // Load 5 rounds of phase 3
-    for (let i = 0; i < 5; i++) {
-      phase3Data.push(await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(i)))
-      aggregatorFake.getRoundData.whenCalledWith(PHASE_3_STARTING_ROUND.add(i)).returns(phase3Data[i])
-    }
-
-    // Load 5 rounds of phase 4
-    for (let i = 0; i < 5; i++) {
-      phase4Data.push(await aggregatorProxy.getRoundData(PHASE_4_STARTING_ROUND.add(i)))
-      aggregatorFake.getRoundData.whenCalledWith(PHASE_4_STARTING_ROUND.add(i)).returns(phase4Data[i])
-    }
-
-    // Load 5 rounds of phase 5
-    for (let i = 0; i < 5; i++) {
-      phase5Data.push(await aggregatorProxy.getRoundData(PHASE_5_STARTING_ROUND.add(i)))
-      aggregatorFake.getRoundData.whenCalledWith(PHASE_5_STARTING_ROUND.add(i)).returns(phase5Data[i])
-    }
-
-    aggregatorFake.latestRoundData.returns(phase3Data[0])
-    oracle = await new ChainlinkFeedOracle__factory(owner).deploy(aggregatorFake.address)
+    oracle = await new ChainlinkFeedOracle__factory(owner).deploy(aggregatorMock.address)
   })
 
   describe('#constructor', () => {
     it('sets initial params', async () => {
-      expect(await oracle.aggregator()).to.equal(aggregatorFake.address)
+      expect(await oracle.aggregator()).to.equal(aggregatorMock.address)
     })
 
     it('returns version 0', async () => {
+      const expectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND)
       const atVersion = await oracle.atVersion(0)
-      expect(atVersion.price).to.equal(phase3Data[0].answer.mul(10 ** 10))
-      expect(atVersion.timestamp).to.equal(phase3Data[0].updatedAt)
+      expect(atVersion.price).to.equal(expectedData.answer.mul(10 ** 10))
+      expect(atVersion.timestamp).to.equal(expectedData.updatedAt)
       expect(atVersion.version).to.equal(0)
     })
   })
@@ -87,260 +63,252 @@ describe('ChainlinkFeedOracle', () => {
       const returnValue = await oracle.callStatic.sync()
       oracle.connect(user).sync()
 
-      const expectedPrice = phase3Data[0].answer.mul(10 ** 10)
+      const expectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND)
+      const expectedPrice = expectedData.answer.mul(10 ** 10)
 
       expect(returnValue.price).to.equal(expectedPrice)
-      expect(returnValue.timestamp).to.equal(phase3Data[0].updatedAt)
+      expect(returnValue.timestamp).to.equal(expectedData.updatedAt)
       expect(returnValue.version).to.equal(0)
 
       const currentVersion = await oracle.currentVersion()
       expect(currentVersion.price).to.equal(expectedPrice)
-      expect(currentVersion.timestamp).to.equal(phase3Data[0].updatedAt)
+      expect(currentVersion.timestamp).to.equal(expectedData.updatedAt)
       expect(currentVersion.version).to.equal(0)
 
       const atVersion = await oracle.atVersion(0)
       expect(atVersion.price).to.equal(expectedPrice)
-      expect(atVersion.timestamp).to.equal(phase3Data[0].updatedAt)
+      expect(atVersion.timestamp).to.equal(expectedData.updatedAt)
       expect(atVersion.version).to.equal(0)
     })
 
     describe('after synced', async () => {
       beforeEach(async () => {
-        aggregatorFake.latestRoundData.returns(phase3Data[1])
+        await aggregatorMock._setLatestRoundData(...(await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(1))))
 
         await oracle.connect(user).sync()
       })
 
       it('doesnt sync new version if not available', async () => {
-        const expectedPrice = phase3Data[1].answer.mul(10 ** 10)
+        const expectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(1))
+        const expectedPrice = expectedData.answer.mul(10 ** 10)
         const returnValue = await oracle.callStatic.sync()
         oracle.connect(user).sync()
 
         expect(returnValue.price).to.equal(expectedPrice)
-        expect(returnValue.timestamp).to.equal(phase3Data[1].updatedAt)
+        expect(returnValue.timestamp).to.equal(expectedData.updatedAt)
         expect(returnValue.version).to.equal(1)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(expectedPrice)
-        expect(currentVersion.timestamp).to.equal(phase3Data[1].updatedAt)
+        expect(currentVersion.timestamp).to.equal(expectedData.updatedAt)
         expect(currentVersion.version).to.equal(1)
 
         const atVersion = await oracle.atVersion(1)
         expect(atVersion.price).to.equal(expectedPrice)
-        expect(atVersion.timestamp).to.equal(phase3Data[1].updatedAt)
+        expect(atVersion.timestamp).to.equal(expectedData.updatedAt)
         expect(atVersion.version).to.equal(1)
       })
 
       it('syncs new version if available', async () => {
-        const expectedPrice = phase3Data[2].answer.mul(10 ** 10)
-        aggregatorFake.latestRoundData.returns(phase3Data[2])
+        const expectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(2))
+        const expectedPrice = expectedData.answer.mul(10 ** 10)
+        await aggregatorMock._setLatestRoundData(...expectedData)
 
         const returnValue = await oracle.callStatic.sync()
         oracle.connect(user).sync()
 
         expect(returnValue.price).to.equal(expectedPrice)
-        expect(returnValue.timestamp).to.equal(phase3Data[2].updatedAt)
+        expect(returnValue.timestamp).to.equal(expectedData.updatedAt)
         expect(returnValue.version).to.equal(2)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(expectedPrice)
-        expect(currentVersion.timestamp).to.equal(phase3Data[2].updatedAt)
+        expect(currentVersion.timestamp).to.equal(expectedData.updatedAt)
         expect(currentVersion.version).to.equal(2)
 
         const atVersion = await oracle.atVersion(2)
         expect(atVersion.price).to.equal(expectedPrice)
-        expect(atVersion.timestamp).to.equal(phase3Data[2].updatedAt)
+        expect(atVersion.timestamp).to.equal(expectedData.updatedAt)
         expect(atVersion.version).to.equal(2)
       })
 
       it('syncs with new phase', async () => {
         // Sync up to version 3 which is in Phase 3
-        aggregatorFake.latestRoundData.returns(phase3Data[3])
+        await aggregatorMock._setLatestRoundData(...(await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(3))))
         await oracle.connect(user).sync()
 
         // Next round comes from phase 4.
         // We check if there is another round in phase 3 (there is, which is version 4) so this corresponds to Version 5
-        aggregatorFake.latestRoundData.returns(phase4Data[1])
+        const expectedData = await aggregatorProxy.getRoundData(PHASE_4_STARTING_ROUND.add(1))
+        await aggregatorMock._setLatestRoundData(...expectedData)
 
-        const expectedPrice = phase4Data[1].answer.mul(10 ** 10)
+        const expectedPrice = expectedData.answer.mul(10 ** 10)
         const returnValue = await oracle.callStatic.sync()
         await oracle.connect(user).sync()
 
         expect(returnValue.price).to.equal(expectedPrice)
-        expect(returnValue.timestamp).to.equal(phase4Data[1].updatedAt)
+        expect(returnValue.timestamp).to.equal(expectedData.updatedAt)
         expect(returnValue.version).to.equal(5)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(expectedPrice)
-        expect(currentVersion.timestamp).to.equal(phase4Data[1].updatedAt)
+        expect(currentVersion.timestamp).to.equal(expectedData.updatedAt)
         expect(currentVersion.version).to.equal(5)
 
         const atVersion5 = await oracle.atVersion(5)
         expect(atVersion5.price).to.equal(expectedPrice)
-        expect(atVersion5.timestamp).to.equal(phase4Data[1].updatedAt)
+        expect(atVersion5.timestamp).to.equal(expectedData.updatedAt)
         expect(atVersion5.version).to.equal(5)
 
+        const version4ExpectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(4))
         const atVersion4 = await oracle.atVersion(4)
-        expect(atVersion4.price).to.equal(phase3Data[4].answer.mul(10 ** 10))
-        expect(atVersion4.timestamp).to.equal(phase3Data[4].updatedAt)
+        expect(atVersion4.price).to.equal(version4ExpectedData.answer.mul(10 ** 10))
+        expect(atVersion4.timestamp).to.equal(version4ExpectedData.updatedAt)
         expect(atVersion4.version).to.equal(4)
       })
 
       it('syncs with new phase, next round in previous phase after latest round', async () => {
+        const p3r1237 = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(3))
+        const p3r1238 = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(4))
+        const p4r544 = await aggregatorProxy.getRoundData(PHASE_4_STARTING_ROUND.add(1))
+
         // Sync up to version 3 which is in Phase 3
-        aggregatorFake.latestRoundData.returns(phase3Data[3])
-        aggregatorFake.getRoundData.whenCalledWith(phase3Data[4].roundId).returns([
-          phase3Data[4].roundId,
-          phase3Data[4].answer,
-          phase4Data[1].startedAt, // Force this round to be after the newly synced one
-          phase4Data[1].updatedAt,
-          phase3Data[4].roundId,
+        await aggregatorMock._setLatestRoundData(...p3r1237)
+        aggregatorMock.getRoundData.whenCalledWith(PHASE_3_STARTING_ROUND.add(4)).returns([
+          p3r1238.roundId,
+          p3r1238.answer,
+          p4r544.startedAt, // Force this round to be after the newly synced one
+          p4r544.updatedAt,
+          p3r1238.roundId,
         ])
         await oracle.connect(user).sync()
 
         // Next round comes from phase 4.
         // We check if there is another round in phase 3
-        // There is, but it is after phase4Data[1] so we ignore it and perform a walkback
-        // The walkback goes back 1 round in the new phase, so this is version 5
-        aggregatorFake.latestRoundData.returns(phase4Data[1])
+        // There is, but it is after phase4Data[1] so we ignore it and perform a search
+        // The search will phase 4 starts at round 2 (version 4), so this is version 4 + (544 - 2) = 546
+        await aggregatorMock._setLatestRoundData(...p4r544)
 
-        const expectedPrice = phase4Data[1].answer.mul(10 ** 10)
+        const expectedPrice = p4r544.answer.mul(10 ** 10)
         const returnValue = await oracle.callStatic.sync()
         await oracle.connect(user).sync()
 
         expect(returnValue.price).to.equal(expectedPrice)
-        expect(returnValue.timestamp).to.equal(phase4Data[1].updatedAt)
-        expect(returnValue.version).to.equal(5)
+        expect(returnValue.timestamp).to.equal(p4r544.updatedAt)
+        expect(returnValue.version).to.equal(546)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(expectedPrice)
-        expect(currentVersion.timestamp).to.equal(phase4Data[1].updatedAt)
-        expect(currentVersion.version).to.equal(5)
+        expect(currentVersion.timestamp).to.equal(p4r544.updatedAt)
+        expect(currentVersion.version).to.equal(546)
 
-        const atVersion5 = await oracle.atVersion(5)
+        const atVersion5 = await oracle.atVersion(546)
         expect(atVersion5.price).to.equal(expectedPrice)
-        expect(atVersion5.timestamp).to.equal(phase4Data[1].updatedAt)
-        expect(atVersion5.version).to.equal(5)
+        expect(atVersion5.timestamp).to.equal(p4r544.updatedAt)
+        expect(atVersion5.version).to.equal(546)
 
+        const p4r2 = await aggregatorProxy.getRoundData(buildChainlinkRoundId(4, 2))
         const atVersion4 = await oracle.atVersion(4)
-        expect(atVersion4.price).to.equal(phase4Data[0].answer.mul(10 ** 10))
-        expect(atVersion4.timestamp).to.equal(phase4Data[0].updatedAt)
+        expect(atVersion4.price).to.equal(p4r2.answer.mul(10 ** 10))
+        expect(atVersion4.timestamp).to.equal(p4r2.updatedAt)
         expect(atVersion4.version).to.equal(4)
 
         const atVersion3 = await oracle.atVersion(3)
-        expect(atVersion3.price).to.equal(phase3Data[3].answer.mul(10 ** 10))
-        expect(atVersion3.timestamp).to.equal(phase3Data[3].updatedAt)
+        expect(atVersion3.price).to.equal(p3r1237.answer.mul(10 ** 10))
+        expect(atVersion3.timestamp).to.equal(p3r1237.updatedAt)
         expect(atVersion3.version).to.equal(3)
       })
 
-      it('syncs with new phase with walkback', async () => {
-        // Sync up to version 4 which is in Phase 3
-        aggregatorFake.latestRoundData.returns(phase3Data[4])
-        aggregatorFake.getRoundData.whenCalledWith(PHASE_3_STARTING_ROUND.add(5)).reverts()
+      it('syncs with new phase with search', async () => {
+        const p3r1237 = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(3))
+        const p4r544 = await aggregatorProxy.getRoundData(PHASE_4_STARTING_ROUND.add(1))
+        aggregatorMock.getRoundData.whenCalledWith(PHASE_3_STARTING_ROUND.add(4)).reverts()
+
+        // Sync up to version 3 which is in Phase 3
+        await aggregatorMock._setLatestRoundData(...p3r1237)
+
         await oracle.connect(user).sync()
 
         // Next round comes from phase 4.
-        // We check if there is another round in phase 3 (there is not)
-        // so this corresponds to Version 6 and phase4Data[0] is version 5
-        aggregatorFake.latestRoundData.returns(phase4Data[1])
+        // We check if there is another round in phase 3
+        // There is not
+        // The search will find phase 4 starts at round 2 (version 4), so this is version 4 + (544 - 2) = 546
+        await aggregatorMock._setLatestRoundData(...p4r544)
 
-        const expectedPrice = phase4Data[1].answer.mul(10 ** 10)
+        const expectedPrice = p4r544.answer.mul(10 ** 10)
         const returnValue = await oracle.callStatic.sync()
         await oracle.connect(user).sync()
 
         expect(returnValue.price).to.equal(expectedPrice)
-        expect(returnValue.timestamp).to.equal(phase4Data[1].updatedAt)
-        expect(returnValue.version).to.equal(6)
+        expect(returnValue.timestamp).to.equal(p4r544.updatedAt)
+        expect(returnValue.version).to.equal(546)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(expectedPrice)
-        expect(currentVersion.timestamp).to.equal(phase4Data[1].updatedAt)
-        expect(currentVersion.version).to.equal(6)
+        expect(currentVersion.timestamp).to.equal(p4r544.updatedAt)
+        expect(currentVersion.version).to.equal(546)
 
-        const atVersion6 = await oracle.atVersion(6)
-        expect(atVersion6.price).to.equal(expectedPrice)
-        expect(atVersion6.timestamp).to.equal(phase4Data[1].updatedAt)
-        expect(atVersion6.version).to.equal(6)
+        const atVersion5 = await oracle.atVersion(546)
+        expect(atVersion5.price).to.equal(expectedPrice)
+        expect(atVersion5.timestamp).to.equal(p4r544.updatedAt)
+        expect(atVersion5.version).to.equal(546)
 
-        const atVersion5 = await oracle.atVersion(5)
-        expect(atVersion5.price).to.equal(phase4Data[0].answer.mul(10 ** 10))
-        expect(atVersion5.timestamp).to.equal(phase4Data[0].updatedAt)
-        expect(atVersion5.version).to.equal(5)
-
+        const p4r2 = await aggregatorProxy.getRoundData(buildChainlinkRoundId(4, 2))
         const atVersion4 = await oracle.atVersion(4)
-        expect(atVersion4.price).to.equal(phase3Data[4].answer.mul(10 ** 10))
-        expect(atVersion4.timestamp).to.equal(phase3Data[4].updatedAt)
+        expect(atVersion4.price).to.equal(p4r2.answer.mul(10 ** 10))
+        expect(atVersion4.timestamp).to.equal(p4r2.updatedAt)
         expect(atVersion4.version).to.equal(4)
+
+        const atVersion3 = await oracle.atVersion(3)
+        expect(atVersion3.price).to.equal(p3r1237.answer.mul(10 ** 10))
+        expect(atVersion3.timestamp).to.equal(p3r1237.updatedAt)
+        expect(atVersion3.version).to.equal(3)
       })
 
-      it('syncs with new phase with multi-walkback', async () => {
-        // Sync up to version 4 which is in Phase 3
-        aggregatorFake.latestRoundData.returns(phase3Data[4])
-        aggregatorFake.getRoundData.whenCalledWith(PHASE_3_STARTING_ROUND.add(5)).reverts()
+      it('syncs with new phase 2 phases away from the last', async () => {
+        // Sync up to the very last round in phase 3, version 25380
+        const p3rLAST = await aggregatorProxy.getRoundData(buildChainlinkRoundId(3, 26614))
+        await aggregatorMock._setLatestRoundData(...p3rLAST)
         await oracle.connect(user).sync()
 
-        // Next round comes from phase 4.
-        // We check if there is another round in phase 3 (there is not)
+        // Next round comes from phase 5.
+        // The search will find intermediary phase 4 starts at round 5057 (version 25381), so this is version 25382
+        const p5r756 = await aggregatorProxy.getRoundData(PHASE_5_STARTING_ROUND)
+        await aggregatorMock._setLatestRoundData(...p5r756)
 
-        // Allow the walkback to stop at phase4Data[1] making phase4Data[2] the start of the phase
-        aggregatorFake.getRoundData
-          .whenCalledWith(PHASE_4_STARTING_ROUND.add(1))
-          .returns([
-            phase4Data[1].roundId,
-            phase4Data[1].answer,
-            phase3Data[4].startedAt.sub(5),
-            phase3Data[4].updatedAt.sub(5),
-            phase4Data[1].answeredInRound,
-          ])
-
-        // Due to the walkback, phase4 starts at phase4Data[2], so this is version 7
-        aggregatorFake.latestRoundData.returns(phase4Data[4])
-
-        const expectedPrice = phase4Data[4].answer.mul(10 ** 10)
+        const expectedPrice = p5r756.answer.mul(10 ** 10)
         const returnValue = await oracle.callStatic.sync()
         await oracle.connect(user).sync()
 
         expect(returnValue.price).to.equal(expectedPrice)
-        expect(returnValue.timestamp).to.equal(phase4Data[4].updatedAt)
-        expect(returnValue.version).to.equal(7)
+        expect(returnValue.timestamp).to.equal(p5r756.updatedAt)
+        expect(returnValue.version).to.equal(25382)
 
         const currentVersion = await oracle.currentVersion()
         expect(currentVersion.price).to.equal(expectedPrice)
-        expect(currentVersion.timestamp).to.equal(phase4Data[4].updatedAt)
-        expect(currentVersion.version).to.equal(7)
+        expect(currentVersion.timestamp).to.equal(p5r756.updatedAt)
+        expect(currentVersion.version).to.equal(25382)
 
-        const atVersion7 = await oracle.atVersion(7)
-        expect(atVersion7.price).to.equal(expectedPrice)
-        expect(atVersion7.timestamp).to.equal(phase4Data[4].updatedAt)
-        expect(atVersion7.version).to.equal(7)
+        const atVersionCurrent = await oracle.atVersion(25382)
+        expect(atVersionCurrent.price).to.equal(expectedPrice)
+        expect(atVersionCurrent.timestamp).to.equal(p5r756.updatedAt)
+        expect(atVersionCurrent.version).to.equal(25382)
 
-        const atVersion6 = await oracle.atVersion(6)
-        expect(atVersion6.price).to.equal(phase4Data[3].answer.mul(10 ** 10))
-        expect(atVersion6.timestamp).to.equal(phase4Data[3].updatedAt)
-        expect(atVersion6.version).to.equal(6)
+        const expectedIntermediaryP4 = await aggregatorProxy.getRoundData(buildChainlinkRoundId(4, 5057))
+        const atVersionIntermediary = await oracle.atVersion(25381)
+        expect(atVersionIntermediary.price).to.equal(expectedIntermediaryP4.answer.mul(10 ** 10))
+        expect(atVersionIntermediary.timestamp).to.equal(expectedIntermediaryP4.updatedAt)
+        expect(atVersionIntermediary.version).to.equal(25381)
 
-        const atVersion5 = await oracle.atVersion(5)
-        expect(atVersion5.price).to.equal(phase4Data[2].answer.mul(10 ** 10))
-        expect(atVersion5.timestamp).to.equal(phase4Data[2].updatedAt)
-        expect(atVersion5.version).to.equal(5)
-
-        const atVersion4 = await oracle.atVersion(4)
-        expect(atVersion4.price).to.equal(phase3Data[4].answer.mul(10 ** 10))
-        expect(atVersion4.timestamp).to.equal(phase3Data[4].updatedAt)
-        expect(atVersion4.version).to.equal(4)
-      })
-
-      it('reverts if syncing multiple phases in a single sync call', async () => {
-        aggregatorFake.latestRoundData.returns(phase5Data[0])
-
-        await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'UnableToSyncError')
+        const atVersionP3Last = await oracle.atVersion(25380)
+        expect(atVersionP3Last.price).to.equal(p3rLAST.answer.mul(10 ** 10))
+        expect(atVersionP3Last.timestamp).to.equal(p3rLAST.updatedAt)
+        expect(atVersionP3Last.version).to.equal(25380)
       })
 
       it('reverts on invalid round', async () => {
         const roundId = buildChainlinkRoundId(1, 0)
-        aggregatorFake.latestRoundData
-          .whenCalledWith()
-          .returns([roundId, phase3Data[0].answer, phase3Data[0].startedAt, phase3Data[0].updatedAt, roundId])
+        aggregatorMock.latestRoundData.whenCalledWith().returns([roundId, 123, 123, 123, roundId])
 
         await expect(oracle.connect(user).sync()).to.be.revertedWithCustomError(oracle, 'InvalidOracleRound')
       })
@@ -349,62 +317,65 @@ describe('ChainlinkFeedOracle', () => {
 
   describe('#atVersion', async () => {
     beforeEach(async () => {
-      aggregatorFake.latestRoundData.returns(phase3Data[3])
+      await aggregatorMock._setLatestRoundData(...(await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(3))))
       await oracle.connect(user).sync()
     })
 
     it('reads prior version', async () => {
+      const expectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(1))
       const atVersion = await oracle.atVersion(1)
-      expect(atVersion.price).to.equal(phase3Data[1].answer.mul(10 ** 10))
-      expect(atVersion.timestamp).to.equal(phase3Data[1].updatedAt)
+      expect(atVersion.price).to.equal(expectedData.answer.mul(10 ** 10))
+      expect(atVersion.timestamp).to.equal(expectedData.updatedAt)
       expect(atVersion.version).to.equal(1)
     })
 
     it('reads versions in multiple phases', async () => {
-      // Phase 1 is Versions 0 -> 4
-      // Phase 2 starts at Version 5
-      aggregatorFake.latestRoundData.returns(phase4Data[1])
+      await aggregatorMock._setLatestRoundData(...(await aggregatorProxy.getRoundData(PHASE_4_STARTING_ROUND.add(1))))
 
       // Syncs from Phase 3 to Phase 4
       await oracle.connect(user).sync()
 
       // Syncs from beginning of Phase 4 to end (no more rounds in phase 4)
-      aggregatorFake.latestRoundData.returns(phase4Data[4])
+      const phase4lastRound = buildChainlinkRoundId(4, 5056)
+      await aggregatorMock._setLatestRoundData(...(await aggregatorProxy.getRoundData(phase4lastRound)))
       await oracle.connect(user).sync()
 
-      // Phase2 goes from versions 5 to 8
-      // Start Phase 5, since we triggered a walkback
-      // phase5Data[0] is the starting round of the new phase
-      aggregatorFake.latestRoundData.returns(phase5Data[1])
+      await aggregatorMock._setLatestRoundData(...(await aggregatorProxy.getRoundData(buildChainlinkRoundId(5, 2000))))
       // Syncs from Phase 4 to Phase 5
+      // Search will find the next round is phase 5, round 1434
       await oracle.connect(user).sync()
 
       // Check Version from Phase 3: Versions 0 to 4
       // Check last round of phase3
+      const v4expectedData = await aggregatorProxy.getRoundData(PHASE_3_STARTING_ROUND.add(4))
       const atVersionPhase3 = await oracle.atVersion(4)
-      expect(atVersionPhase3.price).to.equal(phase3Data[4].answer.mul(10 ** 10))
-      expect(atVersionPhase3.timestamp).to.equal(phase3Data[4].updatedAt)
+      expect(atVersionPhase3.price).to.equal(v4expectedData.answer.mul(10 ** 10))
+      expect(atVersionPhase3.timestamp).to.equal(v4expectedData.updatedAt)
       expect(atVersionPhase3.version).to.equal(4)
 
-      // Check Version from Phase 4: Versions 5 to 8
+      // Check Version from Phase 4: Versions 5 to end
       // Check first round of phase4
+      const v5expectedData = await aggregatorProxy.getRoundData(PHASE_4_STARTING_ROUND.add(1))
       const atVersionPhase4 = await oracle.atVersion(5)
-      expect(atVersionPhase4.price).to.equal(phase4Data[1].answer.mul(10 ** 10))
-      expect(atVersionPhase4.timestamp).to.equal(phase4Data[1].updatedAt)
+      expect(atVersionPhase4.price).to.equal(v5expectedData.answer.mul(10 ** 10))
+      expect(atVersionPhase4.timestamp).to.equal(v5expectedData.updatedAt)
       expect(atVersionPhase4.version).to.equal(5)
 
       // Check last round of phase4
-      const atVersionPhase4Last = await oracle.atVersion(8)
-      expect(atVersionPhase4Last.price).to.equal(phase4Data[4].answer.mul(10 ** 10))
-      expect(atVersionPhase4Last.timestamp).to.equal(phase4Data[4].updatedAt)
-      expect(atVersionPhase4Last.version).to.equal(8)
+      // Phase 4 is (5056-544)=4512 rounds long and starts at version 5, so this is version 5+4512=4517
+      const phase4LastExpectedData = await aggregatorProxy.getRoundData(phase4lastRound)
+      const atVersionPhase4Last = await oracle.atVersion(4517)
+      expect(atVersionPhase4Last.price).to.equal(phase4LastExpectedData.answer.mul(10 ** 10))
+      expect(atVersionPhase4Last.timestamp).to.equal(phase4LastExpectedData.updatedAt)
+      expect(atVersionPhase4Last.version).to.equal(4517)
 
-      // Check Version from Phase 5: Versions 9 onwards
-      // Check first round of phase 5
-      const atVersionPhase5 = await oracle.atVersion(9)
-      expect(atVersionPhase5.price).to.equal(phase5Data[0].answer.mul(10 ** 10))
-      expect(atVersionPhase5.timestamp).to.equal(phase5Data[0].updatedAt)
-      expect(atVersionPhase5.version).to.equal(9)
+      // Check Version from Phase 5: Versions 4518 onwards
+      // Check first round of phase 5, which is round 1434 found by the binary search
+      const v9expectedData = await aggregatorProxy.getRoundData(buildChainlinkRoundId(5, 1434))
+      const atVersionPhase5 = await oracle.atVersion(4518)
+      expect(atVersionPhase5.price).to.equal(v9expectedData.answer.mul(10 ** 10))
+      expect(atVersionPhase5.timestamp).to.equal(v9expectedData.updatedAt)
+      expect(atVersionPhase5.version).to.equal(4518)
     })
   })
 })


### PR DESCRIPTION
New binary search logic to find the intermediary round given a phase change. This can handle phase changes that are multiple phases away from the last synced phase using the following algorithm:

1. First, check `if lastSyncedRoundId + 1 exists && (lastsyncedRoundId + 1.timestamp) < currentRound.timestamp` - if true, use that as the next round
2. If (1) is `false` - perform a binary search in the next phase to find the earliest round that is after `lastSyncedRoundId.timestamp`. If there is nothing in the next phase, try the phase after, and so on
3. When recording phases, if there are empty phases between `lastSyncedRoundId` and `intermediaryRoundId` - fill them in with 0 value phases. Similarly, if there are unused phases between `intermediaryRoundId` and `currentRoundId`, do the same