### PR TITLE
Add fee and accumulator events

### DIFF
--- a/packages/perennial/.solcover.js
+++ b/packages/perennial/.solcover.js
@@ -1,0 +1,3 @@
+module.exports = {
+  configureYulOptimizer: true,
+}

--- a/packages/perennial/contracts/interfaces/IProduct.sol
+++ b/packages/perennial/contracts/interfaces/IProduct.sol
@@ -54,6 +54,12 @@ interface IProduct is IPayoffProvider, IParamProvider {
     event MakeClosed(address indexed account, uint256 version, UFixed18 amount);
     event TakeClosed(address indexed account, uint256 version, UFixed18 amount);
     event ClosedUpdated(bool indexed newClosed, uint256 version);
+    event PositionFeeCharged(address indexed account, uint256 version, UFixed18 fee);
+    // Redeclare these events from VersionedAccumulator due to library events not being included in the generated ABI
+    // This is expected to be fixed in Solidity v0.9.x (https://github.com/ethereum/solidity/issues/9765#issuecomment-689396725)
+    event FundingAccumulated(uint256 latestVersion, uint256 toVersion, Accumulator value, UFixed18 fee);
+    event PositionAccumulated(uint256 latestVersion, uint256 toVersion, Accumulator value);
+    event PositionFeeAccumulated(uint256 latestVersion, uint256 toVersion, Accumulator value, UFixed18 fee);
 
     error ProductInsufficientLiquidityError(UFixed18 socializationFactor);
     error ProductDoubleSidedError();

--- a/packages/perennial/contracts/lens/PerennialLens.sol
+++ b/packages/perennial/contracts/lens/PerennialLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.19;
 
 import "../interfaces/IPerennialLens.sol";
 

--- a/packages/perennial/contracts/periphery/CoordinatorDelegatable.sol
+++ b/packages/perennial/contracts/periphery/CoordinatorDelegatable.sol
@@ -43,16 +43,6 @@ contract CoordinatorDelegatable is UOwnable {
     }
 
     /**
-     * @notice Updates the funding fee for product `product` to `newFundingFee`
-     * @dev Only callable by owner or paramAdmin
-     * @param product The product to update
-     * @param newFundingFee The new funding fee
-     */
-    function updateFundingFee(IProduct product, UFixed18 newFundingFee) external onlyOwnerOrParamAdmin {
-        product.updateFundingFee(newFundingFee);
-    }
-
-    /**
      * @notice Updates the maker fee for product `product` to `newMakerFee`
      * @dev Only callable by owner or paramAdmin
      * @param product The product to update
@@ -70,16 +60,6 @@ contract CoordinatorDelegatable is UOwnable {
      */
     function updateTakerFee(IProduct product, UFixed18 newTakerFee) external onlyOwnerOrParamAdmin {
         product.updateTakerFee(newTakerFee);
-    }
-
-    /**
-     * @notice Updates the position fee for product `product` to `newPositionFee`
-     * @dev Only callable by owner or paramAdmin
-     * @param product The product to update
-     * @param newPositionFee The new position fee
-     */
-    function updatePositionFee(IProduct product, UFixed18 newPositionFee) external onlyOwnerOrParamAdmin {
-        product.updatePositionFee(newPositionFee);
     }
 
     /**

--- a/packages/perennial/contracts/periphery/CoordinatorDelegatable.sol
+++ b/packages/perennial/contracts/periphery/CoordinatorDelegatable.sol
@@ -15,8 +15,10 @@ import "../interfaces/IProduct.sol";
  */
 contract CoordinatorDelegatable is UOwnable {
 
+    /// @dev Event emitted when param admin is updated
     event CoordinatorDelegatableParamAdminUpdated(address indexed newParamAdmin);
 
+    /// @dev Error thrown on unauthorized param update call
     error CoordinatorDelegatableNotParamAdminError(address sender);
 
     /// @dev The owner address

--- a/packages/perennial/contracts/periphery/CoordinatorDelegatable.sol
+++ b/packages/perennial/contracts/periphery/CoordinatorDelegatable.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "@equilibria/root/control/unstructured/UOwnable.sol";
+import "@equilibria/root/control/unstructured/UInitializable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "../interfaces/IProduct.sol";
+
+/**
+ * @title CoordinatorDelegatable
+ * @notice Helper contract to allow delegating param updates to address(es)
+ * @dev Creates a coordinator which can delegate param updates to a param admin
+ *      Functions which the param admin can call are allowlisted. If new params are added, this
+ *      owner will not be able to access them unless it is replaced or upgraded (if deployed behind a proxy).
+ */
+contract CoordinatorDelegatable is UOwnable {
+
+    event CoordinatorDelegatableParamAdminUpdated(address indexed newParamAdmin);
+
+    error CoordinatorDelegatableNotParamAdminError(address sender);
+
+    /// @dev The owner address
+    AddressStorage private constant _paramAdmin =
+        AddressStorage.wrap(keccak256("equilibria.perennial.CoordinatorDelegatable.paramAdmin"));
+    function paramAdmin() public view returns (address) { return _paramAdmin.read(); }
+
+    /**
+     * @notice Initializes the coordinator owner contract
+     * @dev Sets the deployer as the default admin and param admin
+     */
+    function initialize() public initializer(1) {
+        __UOwnable__initialize();
+    }
+
+    /**
+     * @notice Updates the maintenance parameter for product `product` to `newMaintenance`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newMaintenance The new maintenance parameter
+     */
+    function updateMaintenance(IProduct product, UFixed18 newMaintenance) external onlyOwnerOrParamAdmin {
+        product.updateMaintenance(newMaintenance);
+    }
+
+    /**
+     * @notice Updates the funding fee for product `product` to `newFundingFee`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newFundingFee The new funding fee
+     */
+    function updateFundingFee(IProduct product, UFixed18 newFundingFee) external onlyOwnerOrParamAdmin {
+        product.updateFundingFee(newFundingFee);
+    }
+
+    /**
+     * @notice Updates the maker fee for product `product` to `newMakerFee`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newMakerFee The new maker fee
+     */
+    function updateMakerFee(IProduct product, UFixed18 newMakerFee) external onlyOwnerOrParamAdmin {
+        product.updateMakerFee(newMakerFee);
+    }
+
+    /**
+     * @notice Updates the taker fee for product `product` to `newTakerFee`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newTakerFee The new taker fee
+     */
+    function updateTakerFee(IProduct product, UFixed18 newTakerFee) external onlyOwnerOrParamAdmin {
+        product.updateTakerFee(newTakerFee);
+    }
+
+    /**
+     * @notice Updates the position fee for product `product` to `newPositionFee`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newPositionFee The new position fee
+     */
+    function updatePositionFee(IProduct product, UFixed18 newPositionFee) external onlyOwnerOrParamAdmin {
+        product.updatePositionFee(newPositionFee);
+    }
+
+    /**
+     * @notice Updates the maker limit for product `product` to `newMakerLimit`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newMakerLimit The new maker limit
+     */
+    function updateMakerLimit(IProduct product, UFixed18 newMakerLimit) external onlyOwnerOrParamAdmin {
+        product.updateMakerLimit(newMakerLimit);
+    }
+
+    /**
+     * @notice Updates the utilization curve for product `product` to `newUtilizationCurve`
+     * @dev Only callable by owner or paramAdmin
+     * @param product The product to update
+     * @param newUtilizationCurve The new utilization curve
+     */
+    function updateUtilizationCurve(IProduct product, JumpRateUtilizationCurve memory newUtilizationCurve) external onlyOwnerOrParamAdmin {
+        product.updateUtilizationCurve(newUtilizationCurve);
+    }
+
+    /**
+     * @notice Updates the param admin to `newParamAdmin`
+     * @dev Only callable by the owner
+     * @param newParamAdmin address of the new param admin
+     */
+    function updateParamAdmin(address newParamAdmin) external onlyOwner {
+        _paramAdmin.store(newParamAdmin);
+
+        emit CoordinatorDelegatableParamAdminUpdated(newParamAdmin);
+    }
+
+    /**
+     * @notice Executes an arbitrary function call or value transfer
+     * @dev Only callable by the owner
+     * @param to The target address
+     * @param data The calldata
+     * @param value The value to transfer
+     */
+    function execute(
+        address payable to,
+        bytes memory data,
+        uint256 value
+    ) payable external onlyOwner returns (bytes memory ret) {
+        if (data.length == 0) {
+            Address.sendValue(to, value);
+        } else {
+            ret = Address.functionCallWithValue(to, data, value);
+        }
+    }
+
+    modifier onlyOwnerOrParamAdmin {
+        if (_sender() != owner() && _sender() != paramAdmin())
+            revert CoordinatorDelegatableNotParamAdminError(_sender());
+        _;
+    }
+}

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.19;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";
@@ -221,7 +221,10 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.openTake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(takerFee());
-        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+        if (!positionFee.isZero()) {
+            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
+        }
 
         emit TakeOpened(account, latestOracleVersion.version, amount);
     }
@@ -258,7 +261,10 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.closeTake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(takerFee());
-        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+        if (!positionFee.isZero()) {
+            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
+        }
 
         emit TakeClosed(account, latestOracleVersion.version, amount);
     }
@@ -295,7 +301,10 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.openMake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(makerFee());
-        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+        if (!positionFee.isZero()) {
+            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
+        }
 
         emit MakeOpened(account, latestOracleVersion.version, amount);
     }
@@ -333,7 +342,10 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.closeMake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(makerFee());
-        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+        if (!positionFee.isZero()) {
+            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
+            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
+        }
 
         emit MakeClosed(account, latestOracleVersion.version, amount);
     }

--- a/packages/perennial/contracts/product/Product.sol
+++ b/packages/perennial/contracts/product/Product.sol
@@ -221,11 +221,9 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.openTake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(takerFee());
-        if (!positionFee.isZero()) {
-            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
-            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
-        }
+        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
 
+        emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
         emit TakeOpened(account, latestOracleVersion.version, amount);
     }
 
@@ -261,11 +259,9 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.closeTake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(takerFee());
-        if (!positionFee.isZero()) {
-            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
-            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
-        }
+        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
 
+        emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
         emit TakeClosed(account, latestOracleVersion.version, amount);
     }
 
@@ -301,11 +297,9 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.openMake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(makerFee());
-        if (!positionFee.isZero()) {
-            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
-            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
-        }
+        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
 
+        emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
         emit MakeOpened(account, latestOracleVersion.version, amount);
     }
 
@@ -342,11 +336,9 @@ contract Product is IProduct, UInitializable, UParamProvider, UPayoffProvider, U
         _position.pre.closeMake(latestOracleVersion.version, amount);
 
         UFixed18 positionFee = amount.mul(latestOracleVersion.price.abs()).mul(makerFee());
-        if (!positionFee.isZero()) {
-            controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
-            emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
-        }
+        if (!positionFee.isZero()) controller().collateral().settleAccount(account, Fixed18Lib.from(-1, positionFee));
 
+        emit PositionFeeCharged(account, latestOracleVersion.version, positionFee);
         emit MakeClosed(account, latestOracleVersion.version, amount);
     }
 

--- a/packages/perennial/hardhat.config.ts
+++ b/packages/perennial/hardhat.config.ts
@@ -10,22 +10,20 @@ import './tasks'
 // function call will likely use extra gas.
 // Mostly inspired by Compound Comet's setup: https://github.com/compound-finance/comet/blob/main/hardhat.config.ts#L124
 const MINIMUM_CONTRACT_SIZE_SOLIDITY_OVERRIDES = {
-  version: '0.8.17',
+  version: '0.8.19',
   settings: {
-    viaIR: OPTIMIZER_ENABLED,
-    optimizer: OPTIMIZER_ENABLED
-      ? {
-          enabled: true,
-          runs: 1,
-          details: {
-            yulDetails: {
-              // We checked with the Compound team to confirm that this should be safe to use to other projects
-              optimizerSteps:
-                'dhfoDgvulfnTUtnIf [xa[r]scLM cCTUtTOntnfDIul Lcul Vcul [j] Tpeul xa[rul] xa[r]cL gvif CTUca[r]LsTOtfDnca[r]Iulc] jmul[jul] VcTOcul jmul',
-            },
-          },
-        }
-      : { enabled: false },
+    viaIR: true,
+    optimizer: {
+      enabled: true,
+      runs: 1,
+      details: {
+        yulDetails: {
+          // We checked with the Compound team to confirm that this should be safe to use to other projects
+          optimizerSteps:
+            'dhfoDgvulfnTUtnIf [xa[r]scLM cCTUtTOntnfDIul Lcul Vcul [j] Tpeul xa[rul] xa[r]cL gvif CTUca[r]LsTOtfDnca[r]Iulc] jmul[jul] VcTOcul jmul',
+        },
+      },
+    },
     outputSelection: OPTIMIZER_ENABLED
       ? {
           '*': {

--- a/packages/perennial/test/integration/core/incentivizer.test.ts
+++ b/packages/perennial/test/integration/core/incentivizer.test.ts
@@ -252,7 +252,7 @@ describe('Incentivizer', () => {
       product0 = await createProduct(instanceVars)
       product1 = await createProduct(instanceVars)
       program0 = await createIncentiveProgram(instanceVars, product0)
-      program1 = await createIncentiveProgram(instanceVars, product1, true, {
+      program1 = await createIncentiveProgram(instanceVars, product1, 2, {
         maker: utils.parseEther('4000'),
         taker: utils.parseEther('1000'),
       })

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -227,8 +227,9 @@ export async function createProduct(
     oracle = chainlinkOracle
   }
 
+  const id = await controller.callStatic.createCoordinator()
   await controller.createCoordinator()
-  await controller.updateCoordinatorTreasury(1, treasuryB.address)
+  await controller.updateCoordinatorTreasury(id, treasuryB.address)
 
   const productInfo = {
     name: 'Squeeth',
@@ -248,8 +249,8 @@ export async function createProduct(
       targetUtilization: utils.parseEther('0.80'),
     },
   }
-  const productAddress = await controller.callStatic.createProduct(1, productInfo)
-  await controller.createProduct(1, productInfo)
+  const productAddress = await controller.callStatic.createProduct(id, productInfo)
+  await controller.createProduct(id, productInfo)
 
   return Product__factory.connect(productAddress, owner)
 }

--- a/packages/perennial/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial/test/integration/helpers/setupHelpers.ts
@@ -258,17 +258,15 @@ export async function createProduct(
 export async function createIncentiveProgram(
   instanceVars: InstanceVars,
   product: Product,
-  nonProtocol = false,
+  coordinatorId = 0,
   amount = { maker: utils.parseEther('8000'), taker: utils.parseEther('2000') },
 ): Promise<BigNumber> {
   const { controller, owner, userC, incentivizer, incentiveToken } = instanceVars
   let programOwner = owner
-  let coordinatorId = 0
-  if (nonProtocol) {
+  if (coordinatorId > 0) {
     programOwner = userC
-    coordinatorId = 1
-    await controller.updateCoordinatorPendingOwner(1, userC.address)
-    await controller.connect(userC).acceptCoordinatorOwner(1)
+    await controller.updateCoordinatorPendingOwner(coordinatorId, userC.address)
+    await controller.connect(userC).acceptCoordinatorOwner(coordinatorId)
   }
   await incentiveToken.mint(programOwner.address, amount.maker.add(amount.taker))
   await incentiveToken.connect(programOwner).approve(incentivizer.address, amount.maker.add(amount.taker))

--- a/packages/perennial/test/integration/periphery/CoordinatorDelegatable.integrationTest.ts
+++ b/packages/perennial/test/integration/periphery/CoordinatorDelegatable.integrationTest.ts
@@ -138,16 +138,10 @@ describe('CoordinatorDelegatable', () => {
       await expect(coordinatorDel.connect(noaccess).updateMaintenance(product.address, 0))
         .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
         .withArgs(noaccess.address)
-      await expect(coordinatorDel.connect(noaccess).updateFundingFee(product.address, 0))
-        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
-        .withArgs(noaccess.address)
       await expect(coordinatorDel.connect(noaccess).updateMakerFee(product.address, 0))
         .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
         .withArgs(noaccess.address)
       await expect(coordinatorDel.connect(noaccess).updateTakerFee(product.address, 0))
-        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
-        .withArgs(noaccess.address)
-      await expect(coordinatorDel.connect(noaccess).updatePositionFee(product.address, 0))
         .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
         .withArgs(noaccess.address)
       await expect(coordinatorDel.connect(noaccess).updateMakerLimit(product.address, 0))
@@ -214,14 +208,6 @@ function itPerformsProductUpdates(getParams: () => [CoordinatorDelegatable, Sign
     expect(await product['maintenance()']()).to.equal(newMaintenance)
   })
 
-  it('can call updateFundingFee', async () => {
-    const newFundingFee = utils.parseEther('0.234')
-
-    await expect(coordinatorDel.connect(signer).updateFundingFee(product.address, newFundingFee)).to.not.be.reverted
-
-    expect(await product.fundingFee()).to.equal(newFundingFee)
-  })
-
   it('can call updateMakerFee', async () => {
     const newMakerFee = utils.parseEther('0.00567')
 
@@ -236,14 +222,6 @@ function itPerformsProductUpdates(getParams: () => [CoordinatorDelegatable, Sign
     await expect(coordinatorDel.connect(signer).updateTakerFee(product.address, newTakerFee)).to.not.be.reverted
 
     expect(await product.takerFee()).to.equal(newTakerFee)
-  })
-
-  it('can call updatePositionFee', async () => {
-    const newPositionFee = utils.parseEther('0.1')
-
-    await expect(coordinatorDel.connect(signer).updatePositionFee(product.address, newPositionFee)).to.not.be.reverted
-
-    expect(await product.positionFee()).to.equal(newPositionFee)
   })
 
   it('can call updateMakerLimit', async () => {

--- a/packages/perennial/test/integration/periphery/CoordinatorDelegatable.integrationTest.ts
+++ b/packages/perennial/test/integration/periphery/CoordinatorDelegatable.integrationTest.ts
@@ -96,6 +96,18 @@ describe('CoordinatorDelegatable', () => {
         await coordinatorDel.execute(instanceVars.controller.address, acceptOwnerData, 0)
       })
 
+      it('can transfer coordinator ownership', async () => {
+        const fn = instanceVars.controller.interface.encodeFunctionData('updateCoordinatorPendingOwner', [
+          1,
+          owner.address,
+        ])
+        await coordinatorDel.execute(instanceVars.controller.address, fn, 0)
+
+        await expect(instanceVars.controller.connect(owner).acceptCoordinatorOwner(1)).to.not.be.reverted
+        expect(await instanceVars.controller['owner(uint256)'](1)).to.equal(owner.address)
+        expect(await instanceVars.controller.coordinatorFor(product.address)).to.equal(1)
+      })
+
       itPerformsProductUpdates(() => [coordinatorDel, owner, product])
     })
   })

--- a/packages/perennial/test/integration/periphery/CoordinatorDelegatable.integrationTest.ts
+++ b/packages/perennial/test/integration/periphery/CoordinatorDelegatable.integrationTest.ts
@@ -1,0 +1,273 @@
+import { expect } from 'chai'
+import 'hardhat'
+import { constants, utils } from 'ethers'
+
+import { InstanceVars, deployProtocol, createProduct } from '../helpers/setupHelpers'
+import {
+  CoordinatorDelegatable,
+  CoordinatorDelegatable__factory,
+  Product,
+  ProxyAdmin,
+  TransparentUpgradeableProxy,
+  TransparentUpgradeableProxy__factory,
+} from '../../../types/generated'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { impersonateWithBalance } from '../../../../common/testutil/impersonate'
+
+describe('CoordinatorDelegatable', () => {
+  let instanceVars: InstanceVars
+  let owner: SignerWithAddress
+  let delegate: SignerWithAddress
+  let noaccess: SignerWithAddress
+  let proxyAdmin: ProxyAdmin
+  let product: Product
+  let impl: CoordinatorDelegatable
+  let proxy: TransparentUpgradeableProxy
+  let coordinatorDel: CoordinatorDelegatable
+
+  beforeEach(async () => {
+    instanceVars = await deployProtocol()
+
+    const controller = instanceVars.controller
+    owner = instanceVars.owner
+    delegate = instanceVars.user
+    noaccess = instanceVars.userB
+    proxyAdmin = instanceVars.proxyAdmin
+    product = await createProduct(instanceVars)
+    impl = await new CoordinatorDelegatable__factory(owner).deploy()
+    proxy = await new TransparentUpgradeableProxy__factory(proxyAdmin.signer).deploy(
+      impl.address,
+      proxyAdmin.address,
+      '0x',
+    )
+    coordinatorDel = CoordinatorDelegatable__factory.connect(proxy.address, owner)
+    await controller.updateCoordinatorPendingOwner(await controller.coordinatorFor(product.address), proxy.address)
+  })
+
+  describe('deployment', () => {
+    it('deploys the impl behind a proxy', async () => {
+      expect(await proxy.connect(proxyAdmin.address).callStatic.admin()).to.equal(proxyAdmin.address)
+      expect(await proxy.connect(proxyAdmin.address).callStatic.implementation()).to.equal(impl.address)
+    })
+  })
+
+  describe('#initialize', () => {
+    it('initializes correctly', async () => {
+      await coordinatorDel.initialize()
+
+      expect(await coordinatorDel.owner()).to.equal(owner.address)
+      expect(await coordinatorDel.paramAdmin()).to.equal(constants.AddressZero)
+    })
+
+    it('reverts if already initialized', async () => {
+      await coordinatorDel.initialize()
+      await expect(coordinatorDel.initialize())
+        .to.be.revertedWithCustomError(coordinatorDel, 'UInitializableAlreadyInitializedError')
+        .withArgs(1)
+    })
+  })
+
+  describe('owner', () => {
+    beforeEach(async () => {
+      await coordinatorDel.initialize()
+    })
+
+    it('can call execute', async () => {
+      const fn = instanceVars.controller.interface.encodeFunctionData('acceptCoordinatorOwner', [1])
+      await expect(coordinatorDel.execute(instanceVars.controller.address, fn, 0)).to.not.be.reverted
+
+      expect(await instanceVars.controller['owner(uint256)'](1)).to.equal(proxy.address)
+      expect(await instanceVars.controller.coordinatorFor(product.address)).to.equal(1)
+
+      await expect(coordinatorDel.execute(owner.address, '0x', 0)).to.not.be.reverted
+    })
+
+    it('can grant and revoke param admin role', async () => {
+      await expect(coordinatorDel.updateParamAdmin(delegate.address)).to.not.be.reverted
+      expect(await coordinatorDel.paramAdmin()).to.equal(delegate.address)
+
+      await expect(coordinatorDel.updateParamAdmin(constants.AddressZero)).to.not.be.reverted
+      expect(await coordinatorDel.paramAdmin()).to.equal(constants.AddressZero)
+    })
+
+    context('as product owner', () => {
+      beforeEach(async () => {
+        const acceptOwnerData = instanceVars.controller.interface.encodeFunctionData('acceptCoordinatorOwner', [1])
+        await coordinatorDel.execute(instanceVars.controller.address, acceptOwnerData, 0)
+      })
+
+      itPerformsProductUpdates(() => [coordinatorDel, owner, product])
+    })
+  })
+
+  describe('paramAdmin', () => {
+    beforeEach(async () => {
+      await coordinatorDel.initialize()
+
+      const acceptOwnerData = instanceVars.controller.interface.encodeFunctionData('acceptCoordinatorOwner', [1])
+      await coordinatorDel.execute(instanceVars.controller.address, acceptOwnerData, 0)
+
+      await coordinatorDel.updateParamAdmin(delegate.address)
+    })
+
+    itPerformsProductUpdates(() => [coordinatorDel, delegate, product])
+
+    it('cannot execute arbitrary functions', async () => {
+      const fn = product.interface.encodeFunctionData('updateOracle', [product.address])
+      await expect(coordinatorDel.connect(delegate).execute(product.address, fn, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'UOwnableNotOwnerError')
+        .withArgs(delegate.address)
+    })
+
+    it('cannot update the param admin', async () => {
+      await expect(coordinatorDel.connect(delegate).updateParamAdmin(delegate.address))
+        .to.be.revertedWithCustomError(coordinatorDel, 'UOwnableNotOwnerError')
+        .withArgs(delegate.address)
+    })
+  })
+
+  describe('noaccess', () => {
+    it('cannot execute arbitrary functions', async () => {
+      const fn = product.interface.encodeFunctionData('updateOracle', [product.address])
+      await expect(coordinatorDel.connect(noaccess).execute(product.address, fn, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'UOwnableNotOwnerError')
+        .withArgs(noaccess.address)
+    })
+
+    it('cannot call any param admin functions', async () => {
+      await expect(coordinatorDel.connect(noaccess).updateMaintenance(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateFundingFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateMakerFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateTakerFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updatePositionFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateMakerLimit(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(
+        coordinatorDel.connect(noaccess).updateUtilizationCurve(product.address, {
+          minRate: 0,
+          maxRate: 0,
+          targetRate: 0,
+          targetUtilization: 0,
+        }),
+      )
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+    })
+  })
+
+  describe('upgradability', () => {
+    beforeEach(async () => {
+      await coordinatorDel.initialize()
+      const proxyAdminSigner = await impersonateWithBalance(proxyAdmin.address, utils.parseEther('1'))
+      proxy = proxy.connect(proxyAdminSigner)
+    })
+
+    it('can upgrade to a new impl', async () => {
+      const newImpl = await new CoordinatorDelegatable__factory(owner).deploy()
+      await expect(proxy.upgradeTo(newImpl.address)).to.not.be.reverted
+      expect(await proxy.callStatic.implementation()).to.equal(newImpl.address)
+    })
+
+    context('after upgrade', () => {
+      beforeEach(async () => {
+        await coordinatorDel.updateParamAdmin(delegate.address)
+        const newImpl = await new CoordinatorDelegatable__factory(owner).deploy()
+        await proxy.upgradeTo(newImpl.address)
+      })
+
+      it('maintains correct state', async () => {
+        await expect(coordinatorDel.initialize())
+          .to.be.revertedWithCustomError(coordinatorDel, 'UInitializableAlreadyInitializedError')
+          .withArgs(1)
+        expect(await coordinatorDel.owner()).to.equal(owner.address)
+        expect(await coordinatorDel.paramAdmin()).to.equal(delegate.address)
+      })
+    })
+  })
+})
+
+function itPerformsProductUpdates(getParams: () => [CoordinatorDelegatable, SignerWithAddress, Product]) {
+  let coordinatorDel: CoordinatorDelegatable
+  let signer: SignerWithAddress
+  let product: Product
+
+  beforeEach(() => {
+    ;[coordinatorDel, signer, product] = getParams()
+  })
+
+  it('can call updateMaintenance', async () => {
+    const newMaintenance = utils.parseEther('0.025')
+
+    await expect(coordinatorDel.connect(signer).updateMaintenance(product.address, newMaintenance)).to.not.be.reverted
+
+    expect(await product['maintenance()']()).to.equal(newMaintenance)
+  })
+
+  it('can call updateFundingFee', async () => {
+    const newFundingFee = utils.parseEther('0.234')
+
+    await expect(coordinatorDel.connect(signer).updateFundingFee(product.address, newFundingFee)).to.not.be.reverted
+
+    expect(await product.fundingFee()).to.equal(newFundingFee)
+  })
+
+  it('can call updateMakerFee', async () => {
+    const newMakerFee = utils.parseEther('0.00567')
+
+    await expect(coordinatorDel.connect(signer).updateMakerFee(product.address, newMakerFee)).to.not.be.reverted
+
+    expect(await product.makerFee()).to.equal(newMakerFee)
+  })
+
+  it('can call updateTakerFee', async () => {
+    const newTakerFee = utils.parseEther('0.012')
+
+    await expect(coordinatorDel.connect(signer).updateTakerFee(product.address, newTakerFee)).to.not.be.reverted
+
+    expect(await product.takerFee()).to.equal(newTakerFee)
+  })
+
+  it('can call updatePositionFee', async () => {
+    const newPositionFee = utils.parseEther('0.1')
+
+    await expect(coordinatorDel.connect(signer).updatePositionFee(product.address, newPositionFee)).to.not.be.reverted
+
+    expect(await product.positionFee()).to.equal(newPositionFee)
+  })
+
+  it('can call updateMakerLimit', async () => {
+    const newMakerLimit = utils.parseEther('12345')
+
+    await expect(coordinatorDel.connect(signer).updateMakerLimit(product.address, newMakerLimit)).to.not.be.reverted
+
+    expect(await product.makerLimit()).to.equal(newMakerLimit)
+  })
+
+  it('can call updateUtilizationCurve', async () => {
+    const newCurve = {
+      minRate: utils.parseEther('0.01'),
+      maxRate: utils.parseEther('1'),
+      targetRate: utils.parseEther('0.5'),
+      targetUtilization: utils.parseEther('0.8'),
+    }
+
+    await expect(coordinatorDel.connect(signer).updateUtilizationCurve(product.address, newCurve)).to.not.be.reverted
+
+    const updatedCurve = await product.utilizationCurve()
+    expect(updatedCurve.minRate).to.equal(newCurve.minRate)
+    expect(updatedCurve.maxRate).to.equal(newCurve.maxRate)
+    expect(updatedCurve.targetRate).to.equal(newCurve.targetRate)
+    expect(updatedCurve.targetUtilization).to.equal(newCurve.targetUtilization)
+  })
+}

--- a/packages/perennial/test/unit/periphery/CooordinatorDelegatable.test.ts
+++ b/packages/perennial/test/unit/periphery/CooordinatorDelegatable.test.ts
@@ -123,16 +123,10 @@ describe('CoordinatorDelegatable', () => {
       await expect(coordinatorDel.connect(noaccess).updateMaintenance(product.address, 0))
         .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
         .withArgs(noaccess.address)
-      await expect(coordinatorDel.connect(noaccess).updateFundingFee(product.address, 0))
-        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
-        .withArgs(noaccess.address)
       await expect(coordinatorDel.connect(noaccess).updateMakerFee(product.address, 0))
         .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
         .withArgs(noaccess.address)
       await expect(coordinatorDel.connect(noaccess).updateTakerFee(product.address, 0))
-        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
-        .withArgs(noaccess.address)
-      await expect(coordinatorDel.connect(noaccess).updatePositionFee(product.address, 0))
         .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
         .withArgs(noaccess.address)
       await expect(coordinatorDel.connect(noaccess).updateMakerLimit(product.address, 0))
@@ -200,15 +194,6 @@ function itPerformsProductUpdates(
     expect(product.updateMaintenance).to.have.been.calledWith(newMaintenance)
   })
 
-  it('can call updateFundingFee', async () => {
-    const newFundingFee = utils.parseEther('0.234')
-    product.updateFundingFee.whenCalledWith(newFundingFee).returns()
-
-    await expect(coordinatorDel.connect(signer).updateFundingFee(product.address, newFundingFee)).to.not.be.reverted
-
-    expect(product.updateFundingFee).to.have.been.calledWith(newFundingFee)
-  })
-
   it('can call updateMakerFee', async () => {
     const newMakerFee = utils.parseEther('0.00567')
     product.updateMakerFee.whenCalledWith(newMakerFee).returns()
@@ -225,15 +210,6 @@ function itPerformsProductUpdates(
     await expect(coordinatorDel.connect(signer).updateTakerFee(product.address, newTakerFee)).to.not.be.reverted
 
     expect(product.updateTakerFee).to.have.been.calledWith(newTakerFee)
-  })
-
-  it('can call updatePositionFee', async () => {
-    const newPositionFee = utils.parseEther('0.1')
-    product.updatePositionFee.whenCalledWith(newPositionFee).returns()
-
-    await expect(coordinatorDel.connect(signer).updatePositionFee(product.address, newPositionFee)).to.not.be.reverted
-
-    expect(product.updatePositionFee).to.have.been.calledWith(newPositionFee)
   })
 
   it('can call updateMakerLimit', async () => {

--- a/packages/perennial/test/unit/periphery/CooordinatorDelegatable.test.ts
+++ b/packages/perennial/test/unit/periphery/CooordinatorDelegatable.test.ts
@@ -1,0 +1,261 @@
+import { FakeContract, smock } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect, use } from 'chai'
+import HRE from 'hardhat'
+
+import {
+  IProduct,
+  CoordinatorDelegatable,
+  CoordinatorDelegatable__factory,
+  TransparentUpgradeableProxy__factory,
+  TransparentUpgradeableProxy,
+} from '../../../types/generated'
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { constants, utils } from 'ethers'
+
+const { ethers } = HRE
+use(smock.matchers)
+
+describe('CoordinatorDelegatable', () => {
+  let owner: SignerWithAddress
+  let delegate: SignerWithAddress
+  let noaccess: SignerWithAddress
+  let proxyAdmin: SignerWithAddress
+  let product: FakeContract<IProduct>
+  let impl: CoordinatorDelegatable
+  let proxy: TransparentUpgradeableProxy
+  let coordinatorDel: CoordinatorDelegatable
+
+  const fixture = async () => {
+    ;[owner, delegate, noaccess, proxyAdmin] = await ethers.getSigners()
+  }
+
+  beforeEach(async () => {
+    await loadFixture(fixture)
+
+    product = await smock.fake<IProduct>('IProduct')
+    impl = await new CoordinatorDelegatable__factory(owner).deploy()
+    proxy = await new TransparentUpgradeableProxy__factory(proxyAdmin).deploy(impl.address, proxyAdmin.address, '0x')
+    coordinatorDel = CoordinatorDelegatable__factory.connect(proxy.address, owner)
+  })
+
+  describe('deployment', () => {
+    it('deploys the impl behind a proxy', async () => {
+      expect(await proxy.callStatic.admin()).to.equal(proxyAdmin.address)
+      expect(await proxy.callStatic.implementation()).to.equal(impl.address)
+    })
+  })
+
+  describe('#initialize', () => {
+    it('initializes correctly', async () => {
+      await coordinatorDel.initialize()
+
+      expect(await coordinatorDel.owner()).to.equal(owner.address)
+      expect(await coordinatorDel.paramAdmin()).to.equal(constants.AddressZero)
+    })
+
+    it('reverts if already initialized', async () => {
+      await coordinatorDel.initialize()
+      await expect(coordinatorDel.initialize())
+        .to.be.revertedWithCustomError(coordinatorDel, 'UInitializableAlreadyInitializedError')
+        .withArgs(1)
+    })
+  })
+
+  describe('owner', () => {
+    beforeEach(async () => {
+      await coordinatorDel.initialize()
+    })
+
+    it('can call execute', async () => {
+      const fn = product.interface.encodeFunctionData('updateOracle', [product.address])
+      product.updateOracle.whenCalledWith(product.address).returns()
+
+      await expect(coordinatorDel.execute(product.address, fn, 0)).to.not.be.reverted
+
+      expect(product.updateOracle).to.have.been.calledWith(product.address)
+
+      await expect(coordinatorDel.execute(product.address, '0x', 0)).to.not.be.reverted
+    })
+
+    it('can grant and revoke param admin role', async () => {
+      await expect(coordinatorDel.updateParamAdmin(delegate.address)).to.not.be.reverted
+      expect(await coordinatorDel.paramAdmin()).to.equal(delegate.address)
+
+      await expect(coordinatorDel.updateParamAdmin(constants.AddressZero)).to.not.be.reverted
+      expect(await coordinatorDel.paramAdmin()).to.equal(constants.AddressZero)
+    })
+
+    itPerformsProductUpdates(() => [coordinatorDel, owner, product])
+  })
+
+  describe('paramAdmin', () => {
+    beforeEach(async () => {
+      await coordinatorDel.initialize()
+      await coordinatorDel.updateParamAdmin(delegate.address)
+    })
+
+    itPerformsProductUpdates(() => [coordinatorDel, delegate, product])
+
+    it('cannot execute arbitrary functions', async () => {
+      const fn = product.interface.encodeFunctionData('updateOracle', [product.address])
+      await expect(coordinatorDel.connect(delegate).execute(product.address, fn, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'UOwnableNotOwnerError')
+        .withArgs(delegate.address)
+    })
+
+    it('cannot update the param admin', async () => {
+      await expect(coordinatorDel.connect(delegate).updateParamAdmin(delegate.address))
+        .to.be.revertedWithCustomError(coordinatorDel, 'UOwnableNotOwnerError')
+        .withArgs(delegate.address)
+    })
+  })
+
+  describe('noaccess', () => {
+    it('cannot execute arbitrary functions', async () => {
+      const fn = product.interface.encodeFunctionData('updateOracle', [product.address])
+      await expect(coordinatorDel.connect(noaccess).execute(product.address, fn, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'UOwnableNotOwnerError')
+        .withArgs(noaccess.address)
+    })
+
+    it('cannot call any param admin functions', async () => {
+      await expect(coordinatorDel.connect(noaccess).updateMaintenance(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateFundingFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateMakerFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateTakerFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updatePositionFee(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(coordinatorDel.connect(noaccess).updateMakerLimit(product.address, 0))
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+      await expect(
+        coordinatorDel.connect(noaccess).updateUtilizationCurve(product.address, {
+          minRate: 0,
+          maxRate: 0,
+          targetRate: 0,
+          targetUtilization: 0,
+        }),
+      )
+        .to.be.revertedWithCustomError(coordinatorDel, 'CoordinatorDelegatableNotParamAdminError')
+        .withArgs(noaccess.address)
+    })
+  })
+
+  describe('upgradability', () => {
+    beforeEach(async () => {
+      await coordinatorDel.initialize()
+    })
+
+    it('can upgrade to a new impl', async () => {
+      const newImpl = await new CoordinatorDelegatable__factory(owner).deploy()
+      await expect(proxy.upgradeTo(newImpl.address)).to.not.be.reverted
+      expect(await proxy.callStatic.implementation()).to.equal(newImpl.address)
+    })
+
+    context('after upgrade', () => {
+      beforeEach(async () => {
+        await coordinatorDel.updateParamAdmin(delegate.address)
+        const newImpl = await new CoordinatorDelegatable__factory(owner).deploy()
+        await proxy.upgradeTo(newImpl.address)
+      })
+
+      it('maintains correct state', async () => {
+        await expect(coordinatorDel.initialize())
+          .to.be.revertedWithCustomError(coordinatorDel, 'UInitializableAlreadyInitializedError')
+          .withArgs(1)
+        expect(await coordinatorDel.owner()).to.equal(owner.address)
+        expect(await coordinatorDel.paramAdmin()).to.equal(delegate.address)
+      })
+    })
+  })
+})
+
+function itPerformsProductUpdates(
+  getParams: () => [CoordinatorDelegatable, SignerWithAddress, FakeContract<IProduct>],
+) {
+  let coordinatorDel: CoordinatorDelegatable
+  let signer: SignerWithAddress
+  let product: FakeContract<IProduct>
+
+  beforeEach(() => {
+    ;[coordinatorDel, signer, product] = getParams()
+  })
+
+  it('can call updateMaintenance', async () => {
+    const newMaintenance = utils.parseEther('0.025')
+    product.updateMaintenance.whenCalledWith(newMaintenance).returns()
+
+    await expect(coordinatorDel.connect(signer).updateMaintenance(product.address, newMaintenance)).to.not.be.reverted
+
+    expect(product.updateMaintenance).to.have.been.calledWith(newMaintenance)
+  })
+
+  it('can call updateFundingFee', async () => {
+    const newFundingFee = utils.parseEther('0.234')
+    product.updateFundingFee.whenCalledWith(newFundingFee).returns()
+
+    await expect(coordinatorDel.connect(signer).updateFundingFee(product.address, newFundingFee)).to.not.be.reverted
+
+    expect(product.updateFundingFee).to.have.been.calledWith(newFundingFee)
+  })
+
+  it('can call updateMakerFee', async () => {
+    const newMakerFee = utils.parseEther('0.00567')
+    product.updateMakerFee.whenCalledWith(newMakerFee).returns()
+
+    await expect(coordinatorDel.connect(signer).updateMakerFee(product.address, newMakerFee)).to.not.be.reverted
+
+    expect(product.updateMakerFee).to.have.been.calledWith(newMakerFee)
+  })
+
+  it('can call updateTakerFee', async () => {
+    const newTakerFee = utils.parseEther('0.012')
+    product.updateTakerFee.whenCalledWith(newTakerFee).returns()
+
+    await expect(coordinatorDel.connect(signer).updateTakerFee(product.address, newTakerFee)).to.not.be.reverted
+
+    expect(product.updateTakerFee).to.have.been.calledWith(newTakerFee)
+  })
+
+  it('can call updatePositionFee', async () => {
+    const newPositionFee = utils.parseEther('0.1')
+    product.updatePositionFee.whenCalledWith(newPositionFee).returns()
+
+    await expect(coordinatorDel.connect(signer).updatePositionFee(product.address, newPositionFee)).to.not.be.reverted
+
+    expect(product.updatePositionFee).to.have.been.calledWith(newPositionFee)
+  })
+
+  it('can call updateMakerLimit', async () => {
+    const newMakerLimit = utils.parseEther('12345')
+    product.updateMakerLimit.whenCalledWith(newMakerLimit).returns()
+
+    await expect(coordinatorDel.connect(signer).updateMakerLimit(product.address, newMakerLimit)).to.not.be.reverted
+
+    expect(product.updateMakerLimit).to.have.been.calledWith(newMakerLimit)
+  })
+
+  it('can call updateUtilizationCurve', async () => {
+    const newCurve = {
+      minRate: utils.parseEther('0.01'),
+      maxRate: utils.parseEther('1'),
+      targetRate: utils.parseEther('0.5'),
+      targetUtilization: utils.parseEther('0.8'),
+    }
+    product.updateUtilizationCurve.whenCalledWith(newCurve).returns()
+
+    await expect(coordinatorDel.connect(signer).updateUtilizationCurve(product.address, newCurve)).to.not.be.reverted
+
+    expect(product.updateUtilizationCurve).to.have.been.calledWith(newCurve)
+  })
+}


### PR DESCRIPTION
Adds 4 new events to the Product contract

* `PositionFeeCharged(version, amount)` - when a use opens/closes a position which results in a non-zero position fee
* `FundingAccumulated(latestVersion, toVersion, (maker, taker), fee)`  - when funding accumulates as part of the settlement accumulation phase
* `PositionAccumulated(latestVersion, toVersion, (maker, taker))` - when position based pnl accumulates as part of the settlement accumulation phase
* `PositionFeeAccumulated(latestVersion, toVersion, (maker, taker), fee)` - when position fees accumulate (to makers) as part of the settlement accumulation phase. Note that the taker amount will (currently) always be 0, but we are including it for consistency

Note that since currently Solidity library events are included in the ABI (issue [here](https://github.com/ethereum/solidity/issues/9765#issuecomment-689396725)) - manual ABI patching will be necessary until the bug is fixed

Also bumps the Product.sol to Solidity version 0.8.19 for contract sizing requirements.

Settlement gas usage before:
```
······························|·································|··············|·············|·················|···············|··············
|  Product                    ·  settle                         ·       98028  ·     539308  ·         353830  ·           68  ·          -  │
······························|·································|··············|·············|·················|···············|··············
```
After:
```
······························|·································|··············|·············|·················|···············|··············
|  Product                    ·  settle                         ·       98028  ·     556876  ·         363160  ·           68  ·          -  │
······························|·································|··············|·············|·················|···············|··············
```