### PR TITLE
Add more validations in BalancedVault constructor

### DIFF
--- a/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
@@ -87,13 +87,21 @@ contract BalancedVault is IBalancedVault, BalancedVaultDefinition, UInitializabl
     /// @dev Mapping of the latest epoch for any queued deposit / redemption per user
     mapping(address => uint256) private _pendingEpochs;
 
+    /**
+     * @param controller_ The controller contract
+     * @param targetLeverage_ The target leverage for the vault
+     * @param maxCollateral_ The maximum amount of collateral that can be held in the vault
+     * @param marketDefinitions_ The market definitions for the vault
+     * @param previousImplementation_ The previous implementation of the vault. Set to address(0) if there is none
+     */
     constructor(
         IController controller_,
         UFixed18 targetLeverage_,
         UFixed18 maxCollateral_,
-        MarketDefinition[] memory marketDefinitions_
+        MarketDefinition[] memory marketDefinitions_,
+        IBalancedVaultDefinition previousImplementation_
     )
-    BalancedVaultDefinition(controller_, targetLeverage_, maxCollateral_, marketDefinitions_)
+    BalancedVaultDefinition(controller_, targetLeverage_, maxCollateral_, marketDefinitions_, previousImplementation_)
     { }
 
     /**

--- a/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
@@ -11,7 +11,7 @@ import "./BalancedVaultDefinition.sol";
  * @notice ERC4626 vault that manages a 50-50 position between long-short markets of the same payoff on Perennial.
  * @dev Vault deploys and rebalances collateral between the corresponding long and short markets, while attempting to
  *      maintain `targetLeverage` with its open positions at any given time. Deposits are only gated in so much as to cap
- *      the maximum amount of assets in the vault.
+ *      the maximum amount of assets in the vault. The long and short markets are expected o have the same oracle.
  *
  *      The vault has a "delayed mint" mechanism for shares on deposit. After depositing to the vault, a user must wait
  *      until the next settlement of the underlying products in order for shares to be reflected in the getters.
@@ -87,13 +87,12 @@ contract BalancedVault is IBalancedVault, BalancedVaultDefinition, UInitializabl
     mapping(address => uint256) private _pendingEpochs;
 
     constructor(
-        Token18 asset_,
         IController controller_,
         UFixed18 targetLeverage_,
         UFixed18 maxCollateral_,
         MarketDefinition[] memory marketDefinitions_
     )
-    BalancedVaultDefinition(asset_, controller_, targetLeverage_, maxCollateral_, marketDefinitions_)
+    BalancedVaultDefinition(controller_, targetLeverage_, maxCollateral_, marketDefinitions_)
     { }
 
     /**

--- a/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
@@ -11,7 +11,8 @@ import "./BalancedVaultDefinition.sol";
  * @notice ERC4626 vault that manages a 50-50 position between long-short markets of the same payoff on Perennial.
  * @dev Vault deploys and rebalances collateral between the corresponding long and short markets, while attempting to
  *      maintain `targetLeverage` with its open positions at any given time. Deposits are only gated in so much as to cap
- *      the maximum amount of assets in the vault. The long and short markets are expected o have the same oracle.
+ *      the maximum amount of assets in the vault. The long and short markets are expected to have the same oracle and
+ *      opposing payoff functions.
  *
  *      The vault has a "delayed mint" mechanism for shares on deposit. After depositing to the vault, a user must wait
  *      until the next settlement of the underlying products in order for shares to be reflected in the getters.

--- a/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
+++ b/packages/perennial-vaults/contracts/balanced/BalancedVault.sol
@@ -88,6 +88,8 @@ contract BalancedVault is IBalancedVault, BalancedVaultDefinition, UInitializabl
     mapping(address => uint256) private _pendingEpochs;
 
     /**
+     * @notice Constructor for BalancedVaultDefinition
+     * @dev previousImplementation_ is an optional feature that gives extra protections against parameter errors during the upgrade process
      * @param controller_ The controller contract
      * @param targetLeverage_ The target leverage for the vault
      * @param maxCollateral_ The maximum amount of collateral that can be held in the vault

--- a/packages/perennial-vaults/contracts/balanced/BalancedVaultDefinition.sol
+++ b/packages/perennial-vaults/contracts/balanced/BalancedVaultDefinition.sol
@@ -98,7 +98,7 @@ contract BalancedVaultDefinition is IBalancedVaultDefinition {
             if (minWeight_ > marketDefinitions_[marketId].weight) minWeight_ = marketDefinitions_[marketId].weight;
         }
 
-        if (totalWeight_ == 0) revert BalancedVaultDefinitionZeroWeightError();
+        if (totalWeight_ == 0) revert BalancedVaultDefinitionAllZeroWeightError();
 
         totalMarkets = totalMarkets_;
         totalWeight = totalWeight_;

--- a/packages/perennial-vaults/contracts/balanced/BalancedVaultDefinition.sol
+++ b/packages/perennial-vaults/contracts/balanced/BalancedVaultDefinition.sol
@@ -63,6 +63,8 @@ contract BalancedVaultDefinition is IBalancedVaultDefinition {
     uint256 private immutable weight1;
 
     /**
+     * @notice Constructor for BalancedVaultDefinition
+     * @dev previousImplementation_ is an optional feature that gives extra protections against parameter errors during the upgrade process
      * @param controller_ The controller contract
      * @param targetLeverage_ The target leverage for the vault
      * @param maxCollateral_ The maximum amount of collateral that can be held in the vault

--- a/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
+++ b/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
@@ -17,7 +17,7 @@ interface IBalancedVaultDefinition {
     error BalancedVaultDefinitionLongAndShortAreSameProductError();
     error BalancedVaultInvalidProductError(IProduct product);
     error BalancedVaultDefinitionOracleMismatchError();
-    error BalancedVaultDefinitionZeroWeightError();
+    error BalancedVaultDefinitionAllZeroWeightError();
 
     function asset() external view returns (Token18);
     function totalMarkets() external view returns (uint256);

--- a/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
+++ b/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
@@ -12,6 +12,12 @@ interface IBalancedVaultDefinition {
     }
 
     error BalancedVaultDefinitionInvalidMarketIdError();
+    error BalancedVaultDefinitionZeroTargetLeverageError();
+    error BalancedVaultDefinitionNoMarketsError();
+    error BalancedVaultDefinitionLongAndShortAreSameProductError();
+    error BalancedVaultInvalidProductError(IProduct product);
+    error BalancedVaultDefinitionOracleMismatchError();
+    error BalancedVaultDefinitionZeroWeightError();
 
     function asset() external view returns (Token18);
     function totalMarkets() external view returns (uint256);

--- a/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
+++ b/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
@@ -17,6 +17,8 @@ interface IBalancedVaultDefinition {
     error BalancedVaultDefinitionLongAndShortAreSameProductError();
     error BalancedVaultInvalidProductError(IProduct product);
     error BalancedVaultDefinitionOracleMismatchError();
+    error BalancedVaultDefinitionWrongPayoffDirectionError(IProduct product);
+    error BalancedVaultDefinitionMismatchedPayoffDataError();
     error BalancedVaultDefinitionAllZeroWeightError();
 
     function asset() external view returns (Token18);

--- a/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
+++ b/packages/perennial-vaults/contracts/interfaces/IBalancedVaultDefinition.sol
@@ -20,6 +20,7 @@ interface IBalancedVaultDefinition {
     error BalancedVaultDefinitionWrongPayoffDirectionError(IProduct product);
     error BalancedVaultDefinitionMismatchedPayoffDataError();
     error BalancedVaultDefinitionAllZeroWeightError();
+    error BalancedVaultDefinitionMarketsMismatchedWithPreviousImplementationError();
 
     function asset() external view returns (Token18);
     function totalMarkets() external view returns (uint256);

--- a/packages/perennial-vaults/package.json
+++ b/packages/perennial-vaults/package.json
@@ -20,7 +20,7 @@
     "test:integration": "FORK_ENABLED=true FORK_BLOCK_NUMBER=16581533 hardhat test test/integration/**/*",
     "test:verification:arbitrum": "FORK_ENABLED=true FORK_NETWORK=arbitrum FORK_BLOCK_NUMBER=80132631 FORK_USE_REAL_DEPLOYS=true hardhat test test/verification/arbitrum/**/*",
     "coverage": "hardhat coverage --testfiles 'test/unit/**/*'",
-    "coverage:integration": "FORK_ENABLED=true FORK_BLOCK_NUMBER=16581533 hardhat coverage --testfiles 'test/integration/*'",
+    "coverage:integration": "FORK_ENABLED=true FORK_BLOCK_NUMBER=16581533 hardhat coverage --testfiles 'test/integration/**/*'",
     "lint": "eslint --fix --ext '.ts,.js' ./ && solhint 'contracts/**/*.sol' --fix",
     "format": "prettier -w .",
     "clean": "rm -rf cache artifacts types/generated dist deployments/localhost",

--- a/packages/perennial-vaults/test/integration/BalancedVault/balancedVault.test.ts
+++ b/packages/perennial-vaults/test/integration/BalancedVault/balancedVault.test.ts
@@ -146,7 +146,7 @@ describe('BalancedVault', () => {
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionNoMarketsError')
     })
 
-    it('checks that all weights are greater than zero', async () => {
+    it('checks that at least one weight is greater than zero', async () => {
       await expect(
         new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
           {
@@ -155,7 +155,7 @@ describe('BalancedVault', () => {
             weight: 0,
           },
         ]),
-      ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionZeroWeightError')
+      ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionAllZeroWeightError')
 
       // At least one of the weights can be zero as long as not all of them are.
       await expect(

--- a/packages/perennial-vaults/test/integration/BalancedVault/balancedVault.test.ts
+++ b/packages/perennial-vaults/test/integration/BalancedVault/balancedVault.test.ts
@@ -95,13 +95,19 @@ describe('BalancedVault', () => {
     leverage = utils.parseEther('4.0')
     maxCollateral = utils.parseEther('500000')
 
-    vault = await new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-      {
-        long: long.address,
-        short: short.address,
-        weight: 1,
-      },
-    ])
+    vault = await new BalancedVault__factory(owner).deploy(
+      controller.address,
+      leverage,
+      maxCollateral,
+      [
+        {
+          long: long.address,
+          short: short.address,
+          weight: 1,
+        },
+      ],
+      ethers.constants.AddressZero,
+    )
     await vault.initialize('Perennial Vault Alpha')
     asset = IERC20Metadata__factory.connect(await vault.asset(), owner)
 
@@ -142,71 +148,107 @@ describe('BalancedVault', () => {
   describe('#constructor', () => {
     it('checks that there is at least one market', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, []),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionNoMarketsError')
     })
 
     it('checks that at least one weight is greater than zero', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: short.address,
-            weight: 0,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 0,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionAllZeroWeightError')
 
       // At least one of the weights can be zero as long as not all of them are.
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: short.address,
-            weight: 0,
-          },
-          {
-            long: long.address,
-            short: short.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 0,
+            },
+            {
+              long: long.address,
+              short: short.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.not.be.reverted
     })
 
     it('checks that all products are valid', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: '0x0000000000000000000000000000000000000000',
-            short: short.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: '0x0000000000000000000000000000000000000000',
+              short: short.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultInvalidProductError')
     })
 
     it('checks that target leverage is positive', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, 0, maxCollateral, [
-          {
-            long: long.address,
-            short: short.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          0,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionZeroTargetLeverageError')
     })
 
     it('checks that the long and short are not identical', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: long.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: long.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionLongAndShortAreSameProductError')
     })
   })

--- a/packages/perennial-vaults/test/integration/BalancedVault/balancedVaultMulti.test.ts
+++ b/packages/perennial-vaults/test/integration/BalancedVault/balancedVaultMulti.test.ts
@@ -248,7 +248,7 @@ describe('BalancedVault (Multi-Payoff)', () => {
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionNoMarketsError')
     })
 
-    it('checks that all weights are greater than zero', async () => {
+    it('checks that at least one weight is greater than zero', async () => {
       await expect(
         new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
           {
@@ -257,7 +257,7 @@ describe('BalancedVault (Multi-Payoff)', () => {
             weight: 0,
           },
         ]),
-      ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionZeroWeightError')
+      ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionAllZeroWeightError')
 
       // At least one of the weights can be zero as long as not all of them are.
       await expect(

--- a/packages/perennial-vaults/test/integration/BalancedVault/balancedVaultMulti.test.ts
+++ b/packages/perennial-vaults/test/integration/BalancedVault/balancedVaultMulti.test.ts
@@ -163,18 +163,24 @@ describe('BalancedVault (Multi-Payoff)', () => {
     leverage = utils.parseEther('4.0')
     maxCollateral = utils.parseEther('500000')
 
-    vault = await new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-      {
-        long: long.address,
-        short: short.address,
-        weight: 4,
-      },
-      {
-        long: btcLong.address,
-        short: btcShort.address,
-        weight: 1,
-      },
-    ])
+    vault = await new BalancedVault__factory(owner).deploy(
+      controller.address,
+      leverage,
+      maxCollateral,
+      [
+        {
+          long: long.address,
+          short: short.address,
+          weight: 4,
+        },
+        {
+          long: btcLong.address,
+          short: btcShort.address,
+          weight: 1,
+        },
+      ],
+      ethers.constants.AddressZero,
+    )
     await vault.initialize('Perennial Vault Alpha')
     asset = IERC20Metadata__factory.connect(await vault.asset(), owner)
 
@@ -244,83 +250,125 @@ describe('BalancedVault (Multi-Payoff)', () => {
   describe('#constructor', () => {
     it('checks that there is at least one market', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, []),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionNoMarketsError')
     })
 
     it('checks that at least one weight is greater than zero', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: short.address,
-            weight: 0,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 0,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionAllZeroWeightError')
 
       // At least one of the weights can be zero as long as not all of them are.
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: short.address,
-            weight: 0,
-          },
-          {
-            long: long.address,
-            short: short.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 0,
+            },
+            {
+              long: long.address,
+              short: short.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.not.be.reverted
     })
 
     it('checks that all products are valid', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: '0x0000000000000000000000000000000000000000',
-            short: short.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: '0x0000000000000000000000000000000000000000',
+              short: short.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultInvalidProductError')
     })
 
     it('checks that target leverage is positive', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, 0, maxCollateral, [
-          {
-            long: long.address,
-            short: short.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          0,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionZeroTargetLeverageError')
     })
 
     it('checks that the long and short are not identical', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: long.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: long.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionLongAndShortAreSameProductError')
     })
 
     it('checks that the long and short oracles match', async () => {
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: long.address,
-            short: btcShort.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: btcShort.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionOracleMismatchError')
     })
 
@@ -335,13 +383,19 @@ describe('BalancedVault (Multi-Payoff)', () => {
         short: true,
       })
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: incorrectBtcLong.address,
-            short: btcShort.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: incorrectBtcLong.address,
+              short: btcShort.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionWrongPayoffDirectionError')
 
       const incorrectBtcShort = await deployProductOnMainnetFork({
@@ -354,13 +408,19 @@ describe('BalancedVault (Multi-Payoff)', () => {
         short: false,
       })
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: btcLong.address,
-            short: incorrectBtcShort.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: btcLong.address,
+              short: incorrectBtcShort.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionWrongPayoffDirectionError')
     })
 
@@ -388,14 +448,61 @@ describe('BalancedVault (Multi-Payoff)', () => {
       })
 
       await expect(
-        new BalancedVault__factory(owner).deploy(controller.address, leverage, maxCollateral, [
-          {
-            long: btcLongWithPayoffData.address,
-            short: btcShortWithPayoffData.address,
-            weight: 1,
-          },
-        ]),
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: btcLongWithPayoffData.address,
+              short: btcShortWithPayoffData.address,
+              weight: 1,
+            },
+          ],
+          ethers.constants.AddressZero,
+        ),
       ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionMismatchedPayoffDataError')
+    })
+
+    it('checks that there are at least the markets of the previous implementation is a prefix of that of the new implementation ', async () => {
+      // New implementation has fewer products than the previous implementation.
+      await expect(
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: long.address,
+              short: short.address,
+              weight: 4,
+            },
+          ],
+          vault.address,
+        ),
+      ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionMarketsMismatchedWithPreviousImplementationError')
+
+      // Markets are switched around in the new implementation.
+      await expect(
+        new BalancedVault__factory(owner).deploy(
+          controller.address,
+          leverage,
+          maxCollateral,
+          [
+            {
+              long: btcLong.address,
+              short: btcShort.address,
+              weight: 1,
+            },
+            {
+              long: long.address,
+              short: short.address,
+              weight: 4,
+            },
+          ],
+          vault.address,
+        ),
+      ).to.revertedWithCustomError(vault, 'BalancedVaultDefinitionMarketsMismatchedWithPreviousImplementationError')
     })
   })
 

--- a/packages/perennial-vaults/test/integration/helpers/setupHelpers.ts
+++ b/packages/perennial-vaults/test/integration/helpers/setupHelpers.ts
@@ -10,6 +10,7 @@ export interface DeployProductParams extends Partial<Omit<IProduct.ProductInfoSt
   baseCurrency: string
   quoteCurrency: string
   short: boolean
+  payoffOracle?: string
 }
 
 // Deploys a product that uses an oracle based on an oracle in the Chainlink feed registry.
@@ -20,6 +21,7 @@ export async function deployProductOnMainnetFork({
   owner,
   oracle,
   short,
+  payoffOracle,
   maintenance,
   fundingFee,
   makerFee,
@@ -31,7 +33,7 @@ export async function deployProductOnMainnetFork({
   const productInfo: IProduct.ProductInfoStruct = {
     name: name,
     symbol: symbol,
-    payoffDefinition: createPayoffDefinition({ short: short }),
+    payoffDefinition: createPayoffDefinition({ contractAddress: payoffOracle, short: short }),
     oracle: oracle ?? constants.AddressZero,
     maintenance: maintenance ?? utils.parseEther('0.10'),
     fundingFee: fundingFee ?? utils.parseEther('0.00'),

--- a/packages/perennial-vaults/test/verification/arbitrum/PerennialVaults/multiAssetUpgrades.test.ts
+++ b/packages/perennial-vaults/test/verification/arbitrum/PerennialVaults/multiAssetUpgrades.test.ts
@@ -51,6 +51,7 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
       await vault.targetLeverage(),
       await vault.maxCollateral(),
       [{ long, short, weight: utils.parseEther('1') }],
+      ethers.constants.AddressZero,
     )
 
     await proxyAdmin.connect(adminOwner).upgrade(vault.address, newImpl.address)
@@ -77,6 +78,7 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
         await vault.targetLeverage(),
         await vault.maxCollateral(),
         [{ long, short, weight: utils.parseEther('1') }],
+        ethers.constants.AddressZero,
       )
       await proxyAdmin.connect(adminOwner).upgrade(vault.address, newImpl.address)
     })
@@ -108,6 +110,7 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
           { long: market0.long, short: market0.short, weight: utils.parseEther('1') },
           { long: arbLong, short: arbShort, weight: utils.parseEther('0.1') },
         ],
+        ethers.constants.AddressZero,
       )
       await proxyAdmin.connect(adminOwner).upgrade(vault.address, newImplMulti.address)
       await vault.initialize('PerennialVaultAlpha')
@@ -139,6 +142,7 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
             { long: market0.long, short: market0.short, weight: utils.parseEther('0.5') },
             { long: arbLong, short: arbShort, weight: utils.parseEther('0.5') },
           ],
+          ethers.constants.AddressZero,
         )
         await proxyAdmin.connect(adminOwner).upgrade(vault.address, newImplMulti.address)
         await vault.initialize('PerennialVaultAlpha')

--- a/packages/perennial-vaults/test/verification/arbitrum/PerennialVaults/multiAssetUpgrades.test.ts
+++ b/packages/perennial-vaults/test/verification/arbitrum/PerennialVaults/multiAssetUpgrades.test.ts
@@ -47,7 +47,6 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
     ])
 
     const newImpl = await new BalancedVault__factory(signer).deploy(
-      await vault.asset(),
       await vault.controller(),
       await vault.targetLeverage(),
       await vault.maxCollateral(),
@@ -74,7 +73,6 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
       const [long, short] = await Promise.all([prevVault.long(), prevVault.short()])
 
       const newImpl = await new BalancedVault__factory(signer).deploy(
-        await vault.asset(),
         await vault.controller(),
         await vault.targetLeverage(),
         await vault.maxCollateral(),
@@ -103,7 +101,6 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
       ])
 
       const newImplMulti = await new BalancedVault__factory(signer).deploy(
-        await vault.asset(),
         await vault.controller(),
         await vault.targetLeverage(),
         await vault.maxCollateral(),
@@ -135,7 +132,6 @@ describe('Vault - Perennial Vaults - Multi-Asset Upgrade', () => {
         const arbShort = deployments['Product_ShortArbitrum'].address
         const market0 = await vault.markets(0)
         const newImplMulti = await new BalancedVault__factory(signer).deploy(
-          await vault.asset(),
           await vault.controller(),
           await vault.targetLeverage(),
           await vault.maxCollateral(),


### PR DESCRIPTION
Validations added:
- Target leverage must be >0
- There must be at least one market
- Long and short cannot be the same product
- Long and short products must use the same oracle
- Long and short products must have opposing payoffs
- All products must be valid
- There must be at least one non-zero weight

Also fix CI not actually running tests in this package.