### PR TITLE
Upgrade Core/Vault Solidity Versions

### DIFF
--- a/packages/common/hardhat.default.config.ts
+++ b/packages/common/hardhat.default.config.ts
@@ -17,7 +17,7 @@ import 'hardhat-deploy'
 import 'hardhat-dependency-compiler'
 import { getChainId, isArbitrum, isBase, isOptimism, SupportedChain } from './testutil/network'
 
-export const SOLIDITY_VERSION = '0.8.15'
+export const SOLIDITY_VERSION = '0.8.17'
 const PRIVATE_KEY_MAINNET = process.env.PRIVATE_KEY || ''
 const PRIVATE_KEY_TESTNET = process.env.PRIVATE_KEY_TESTNET || ''
 

--- a/packages/perennial-examples/contracts/examples/Squeeth.sol
+++ b/packages/perennial-examples/contracts/examples/Squeeth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@equilibria/perennial/contracts/interfaces/IContractPayoffProvider.sol";
 

--- a/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkFeedOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "./interfaces/IOracleProvider.sol";

--- a/packages/perennial-oracle/contracts/ChainlinkOracle.sol
+++ b/packages/perennial-oracle/contracts/ChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";

--- a/packages/perennial-oracle/contracts/test/PassthroughChainlinkFeed.sol
+++ b/packages/perennial-oracle/contracts/test/PassthroughChainlinkFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol";
 

--- a/packages/perennial-oracle/contracts/test/PassthroughDataFeed.sol
+++ b/packages/perennial-oracle/contracts/test/PassthroughDataFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/packages/perennial-oracle/contracts/test/TestnetChainlinkFeedRegistry.sol
+++ b/packages/perennial-oracle/contracts/test/TestnetChainlinkFeedRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 contract TestnetChainlinkFeedRegistry {
     mapping(address => mapping(address => uint8)) public decimals;

--- a/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol";
 import "./ChainlinkRound.sol";

--- a/packages/perennial-oracle/contracts/types/ChainlinkRound.sol
+++ b/packages/perennial-oracle/contracts/types/ChainlinkRound.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/packages/perennial-vaults/hardhat.config.ts
+++ b/packages/perennial-vaults/hardhat.config.ts
@@ -33,7 +33,6 @@ const MINIMUM_CONTRACT_SIZE_SOLIDITY_OVERRIDES = {
 }
 
 const config = defaultConfig({
-  solidityVersion: '0.8.15',
   solidityOverrides: {
     'contracts/balanced/BalancedVault.sol': MINIMUM_CONTRACT_SIZE_SOLIDITY_OVERRIDES,
     'contracts/balanced/BalancedVaultDefinition.sol': MINIMUM_CONTRACT_SIZE_SOLIDITY_OVERRIDES,

--- a/packages/perennial/contracts/collateral/Collateral.sol
+++ b/packages/perennial/contracts/collateral/Collateral.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity 0.8.17;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/controller/Controller.sol
+++ b/packages/perennial/contracts/controller/Controller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity 0.8.17;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";

--- a/packages/perennial/contracts/incentivizer/Incentivizer.sol
+++ b/packages/perennial/contracts/incentivizer/Incentivizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity 0.8.17;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 import "@equilibria/root/control/unstructured/UReentrancyGuard.sol";

--- a/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
+++ b/packages/perennial/contracts/multiinvoker/MultiInvoker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.15;
+pragma solidity 0.8.17;
 
 import "@equilibria/root/control/unstructured/UInitializable.sol";
 

--- a/packages/perennial/contracts/multiinvoker/MultiInvokerRollup.sol
+++ b/packages/perennial/contracts/multiinvoker/MultiInvokerRollup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.15;
+pragma solidity 0.8.17;
 
 import "./MultiInvoker.sol";
 import "../interfaces/IMultiInvokerRollup.sol";


### PR DESCRIPTION
* Upgrades pinned pragmas in Core to `0.8.17` - Collateral, Controller, MultiInvoker, MultiInvokerRollup, and Incentivizer all upgraded
* Defaults to `0.8.17` in the shared config
* Moves pinned pragmas in `oracle` to floating pragmas to make it easier for other projects to import

Fixes `Inconsistent Solidity compiler versions` and `Risk of encountering known Solidity compiler bugs` from the audit